### PR TITLE
Concurrent: Out of order socket responses

### DIFF
--- a/client/src/action.ts
+++ b/client/src/action.ts
@@ -1,4 +1,4 @@
-export function actionUrl(id:string, action:string):URL {
+export function actionUrl(id:ViewId, action:string):URL {
   let url = new URL(window.location.href)
   url.searchParams.append("id", id)
   url.searchParams.append("action", action)
@@ -17,12 +17,15 @@ export function toSearch(form?:FormData):URLSearchParams | undefined {
   return params
 }
 
-export function actionMessage(id:string, action:string, form?:FormData):ActionMessage {
+export function actionMessage(id:ViewId, action:string, form?:FormData):ActionMessage {
   let url = actionUrl(id, action)
-  return { url, form: toSearch(form) }
+  return { id, url, form: toSearch(form) }
 }
 
 export type ActionMessage = {
+  id: ViewId
   url: URL
   form: URLSearchParams | undefined
 }
+
+export type ViewId = string

--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -6,7 +6,6 @@ import Example.Effects.Debug
 import Web.Hyperbole
 
 
--- this is already running in a different context
 page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es Response
 page = do
   handle content
@@ -14,7 +13,7 @@ page = do
   load $ do
     pure $ do
       col (pad 20) $ do
-        hyper (Contents 1000) $ viewPoll 1
+        hyper (Contents 100) $ viewPoll 1
         hyper (Contents 2000) $ viewPoll 100
 
 
@@ -31,6 +30,7 @@ data ContentsAction
 
 content :: (Hyperbole :> es, Debug :> es, IOE :> es) => Contents -> ContentsAction -> Eff es (View Contents ())
 content (Contents dl) (Load n) = do
+  -- BUG: this is blocking the thread, so the short poll has to wait for the long to finish before continuing
   delay dl
   pure $ viewPoll (n + 1)
 

--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -1,0 +1,89 @@
+module Example.Concurrent where
+
+import Data.Text (pack)
+import Effectful
+import Example.Effects.Debug
+import System.Random (randomRIO)
+import Web.Hyperbole
+
+
+-- this is already running in a different context
+page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es Response
+page = do
+  handle content
+  handle content2
+
+  load $ do
+    pure $ do
+      row (pad 20) $ do
+        col (gap 10 . border 1 . pad 20) $ do
+          hyper Contents viewInit
+        col (gap 10 . border 1 . pad 20) $ do
+          hyper Contents2 viewInit2
+
+
+data Contents = Contents
+  deriving (Generic, Param)
+instance HyperView Contents where
+  type Action Contents = ContentsAction
+
+
+data ContentsAction
+  = Load
+  | Reload Int
+  deriving (Generic, Param)
+
+
+data Contents2 = Contents2
+  deriving (Generic, Param)
+instance HyperView Contents2 where
+  type Action Contents2 = ContentsAction2
+
+
+data ContentsAction2
+  = Load2
+  | Reload2 Int
+  deriving (Generic, Param)
+
+
+content :: (Hyperbole :> es, Debug :> es, IOE :> es) => Contents -> ContentsAction -> Eff es (View Contents ())
+content _ Load = do
+  -- Pretend the initial Load takes 1s to complete
+  liftIO (randomRIO (50, 150)) >>= delay
+  pure $ onLoad (Reload 1) 100 $ el (color (HexColor "00ff00")) $ do
+    el id "Loaded, should reload once more..."
+content _ (Reload n) = do
+  liftIO (randomRIO (50, 150)) >>= delay
+  -- then reload after a 1s delay (client-side)
+  pure $ onLoad (Reload (n + 1)) 100 $ do
+    col (gap 10) $ el (color (HexColor "00ff00")) $ do
+      el_ "Reloaded! polling..."
+      el_ $ text $ pack $ show n
+
+
+content2 :: (Hyperbole :> es, Debug :> es, IOE :> es) => Contents2 -> ContentsAction2 -> Eff es (View Contents2 ())
+content2 _ Load2 = do
+  -- Pretend the initial Load takes 1s to complete
+  liftIO (randomRIO (50, 550)) >>= delay
+  pure $ onLoad (Reload2 10000) 100 $ el (color (HexColor "ff0000")) $ do
+    el id "Loaded, should reload once more..."
+content2 _ (Reload2 n) = do
+  liftIO (randomRIO (50, 550)) >>= delay
+  -- then reload after a 1s delay (client-side)
+  pure $ onLoad (Reload2 (n + 1)) 100 $ do
+    col (gap 10) $ el (color (HexColor "ff0000")) $ do
+      el_ "Reloaded! polling..."
+      el_ $ text $ pack $ show n
+      button (Reload2 (n + 1000)) id "Add"
+
+
+viewInit :: View Contents ()
+viewInit = do
+  onLoad Load 0 $ do
+    el (color (HexColor "00ff00")) "Lazy Loading..."
+
+
+viewInit2 :: View Contents2 ()
+viewInit2 = do
+  onLoad Load2 0 $ do
+    el (color (HexColor "ff0000")) "Lazy Loading..."

--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -3,7 +3,6 @@ module Example.Concurrent where
 import Data.Text (pack)
 import Effectful
 import Example.Effects.Debug
-import System.Random (randomRIO)
 import Web.Hyperbole
 
 
@@ -11,79 +10,34 @@ import Web.Hyperbole
 page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es Response
 page = do
   handle content
-  handle content2
 
   load $ do
     pure $ do
-      row (pad 20) $ do
-        col (gap 10 . border 1 . pad 20) $ do
-          hyper Contents viewInit
-        col (gap 10 . border 1 . pad 20) $ do
-          hyper Contents2 viewInit2
+      col (pad 20) $ do
+        hyper (Contents 1000) $ viewPoll 1
+        hyper (Contents 2000) $ viewPoll 100
 
 
-data Contents = Contents
+data Contents = Contents Milliseconds
   deriving (Generic, Param)
 instance HyperView Contents where
   type Action Contents = ContentsAction
 
 
 data ContentsAction
-  = Load
-  | Reload Int
-  deriving (Generic, Param)
-
-
-data Contents2 = Contents2
-  deriving (Generic, Param)
-instance HyperView Contents2 where
-  type Action Contents2 = ContentsAction2
-
-
-data ContentsAction2
-  = Load2
-  | Reload2 Int
+  = Load Int
   deriving (Generic, Param)
 
 
 content :: (Hyperbole :> es, Debug :> es, IOE :> es) => Contents -> ContentsAction -> Eff es (View Contents ())
-content _ Load = do
-  -- Pretend the initial Load takes 1s to complete
-  liftIO (randomRIO (50, 150)) >>= delay
-  pure $ onLoad (Reload 1) 100 $ el (color (HexColor "00ff00")) $ do
-    el id "Loaded, should reload once more..."
-content _ (Reload n) = do
-  liftIO (randomRIO (50, 150)) >>= delay
-  -- then reload after a 1s delay (client-side)
-  pure $ onLoad (Reload (n + 1)) 100 $ do
-    col (gap 10) $ el (color (HexColor "00ff00")) $ do
-      el_ "Reloaded! polling..."
-      el_ $ text $ pack $ show n
+content (Contents dl) (Load n) = do
+  delay dl
+  pure $ viewPoll (n + 1)
 
 
-content2 :: (Hyperbole :> es, Debug :> es, IOE :> es) => Contents2 -> ContentsAction2 -> Eff es (View Contents2 ())
-content2 _ Load2 = do
-  -- Pretend the initial Load takes 1s to complete
-  liftIO (randomRIO (50, 550)) >>= delay
-  pure $ onLoad (Reload2 10000) 100 $ el (color (HexColor "ff0000")) $ do
-    el id "Loaded, should reload once more..."
-content2 _ (Reload2 n) = do
-  liftIO (randomRIO (50, 550)) >>= delay
-  -- then reload after a 1s delay (client-side)
-  pure $ onLoad (Reload2 (n + 1)) 100 $ do
-    col (gap 10) $ el (color (HexColor "ff0000")) $ do
-      el_ "Reloaded! polling..."
-      el_ $ text $ pack $ show n
-      button (Reload2 (n + 1000)) id "Add"
-
-
-viewInit :: View Contents ()
-viewInit = do
-  onLoad Load 0 $ do
-    el (color (HexColor "00ff00")) "Lazy Loading..."
-
-
-viewInit2 :: View Contents2 ()
-viewInit2 = do
-  onLoad Load2 0 $ do
-    el (color (HexColor "ff0000")) "Lazy Loading..."
+viewPoll :: Int -> View Contents ()
+viewPoll n = do
+  onLoad (Load n) 0 $ do
+    row (gap 10) $ do
+      el_ "Polling:"
+      text $ pack (show n)

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -17,6 +17,7 @@ import Effectful.Concurrent.STM
 import Effectful.Dispatch.Dynamic
 import Effectful.Reader.Static
 import Effectful.State.Static.Local
+import Example.Concurrent qualified as Concurrent
 import Example.Contacts qualified as Contacts
 import Example.Counter qualified as Counter
 import Example.Effects.Debug as Debug
@@ -64,6 +65,7 @@ data AppRoute
   | Redirects
   | RedirectNow
   | LazyLoading
+  | Concurrent
   | Errors
   deriving (Eq, Generic, Route)
 
@@ -92,6 +94,7 @@ app users count = do
   router Forms = page Forms.page
   router Sessions = page Sessions.page
   router LazyLoading = page LazyLoading.page
+  router Concurrent = page Concurrent.page
   router Redirects = page Redirects.page
   router Errors = page Errors.page
   router RedirectNow = do

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -80,6 +80,7 @@ executable examples
   other-modules:
       BulkUpdate
       Example.Colors
+      Example.Concurrent
       Example.Contacts
       Example.Counter
       Example.Effects.Debug


### PR DESCRIPTION
Non-draft implementation of #6 

* Minimal Reproduce Example
* Server responds with view-ids
* Promises ignore responses not intended for them

Fixes the main issue described in #5 