### PR TITLE
Serialize ids

### DIFF
--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -39,7 +39,7 @@ data ContactsAction
 data Filter
   = Active
   | Inactive
-  deriving (Eq, Generic, Param)
+  deriving (Eq, Show, Read)
 
 
 instance HyperView Contacts where

--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -27,13 +27,13 @@ page = do
 -- Contacts ----------------------------------------------
 
 data Contacts = Contacts
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data ContactsAction
   = Reload (Maybe Filter)
   | Delete Int
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 data Filter
@@ -83,14 +83,14 @@ allContactsView fil us = do
 -- Contact ----------------------------------------------------
 
 data Contact = Contact Int
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data ContactAction
   = Edit
   | Save
   | View
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Contact where

--- a/example/Example/Counter.hs
+++ b/example/Example/Counter.hs
@@ -22,7 +22,7 @@ page var = do
 
 
 data Counter = Counter
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 instance HyperView Counter where
   type Action Counter = Count
 
@@ -30,7 +30,7 @@ instance HyperView Counter where
 data Count
   = Increment
   | Decrement
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 counter :: (Hyperbole :> es, Concurrent :> es) => TVar Int -> Counter -> Count -> Eff es (View Counter ())

--- a/example/Example/Errors.hs
+++ b/example/Example/Errors.hs
@@ -17,12 +17,12 @@ page = do
 
 
 data Contents = Contents
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data ContentsAction
   = CauseError
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Contents where

--- a/example/Example/Forms.hs
+++ b/example/Example/Forms.hs
@@ -18,11 +18,11 @@ page = do
 
 
 data FormView = FormView
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data FormAction = Submit
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView FormView where
@@ -86,8 +86,6 @@ formView v = do
     submit Style.btn "Submit"
  where
   inp = border 1 . pad 8
-
-
 
 
 userView :: User -> Age -> Pass1 -> View FormView ()

--- a/example/Example/LazyLoading.hs
+++ b/example/Example/LazyLoading.hs
@@ -19,7 +19,7 @@ page = do
 
 
 data Contents = Contents
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 instance HyperView Contents where
   type Action Contents = ContentsAction
 
@@ -27,7 +27,7 @@ instance HyperView Contents where
 data ContentsAction
   = Load
   | Reload Int
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 content :: (Hyperbole :> es, Debug :> es) => Contents -> ContentsAction -> Eff es (View Contents ())

--- a/example/Example/Redirects.hs
+++ b/example/Example/Redirects.hs
@@ -15,12 +15,12 @@ page = do
 
 
 data Contents = Contents
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data ContentsAction
   = RedirectAsAction
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Contents where

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -22,20 +22,16 @@ page = do
     pure $ col (pad 20 . gap 10) $ do
       el_ "Reload your browser after changing the settings below to see the session information preserved"
       row id $ do
-        hyper (Contents (Woot 3) "hello bobby") $ viewContent clr msg
+        hyper Contents $ viewContent clr msg
 
 
-data Contents = Contents Woot Text
+data Contents = Contents
   deriving (Generic, ViewId)
-
-
-newtype Woot = Woot Int
-  deriving newtype (Param)
 
 
 data ContentsAction
   = SaveColor AppColor
-  | SaveMessage Text Int
+  | SaveMessage Text
   deriving (Generic, ViewAction)
 
 
@@ -48,7 +44,7 @@ content _ (SaveColor clr) = do
   setSession "color" clr
   msg <- session "msg"
   pure $ viewContent (Just clr) msg
-content _ (SaveMessage msg _) = do
+content _ (SaveMessage msg) = do
   setSession "msg" msg
   clr <- session "color"
   pure $ viewContent clr (Just msg)
@@ -79,6 +75,6 @@ viewMessage mm = do
     el (fontSize 24 . bold) "Session Message:"
     el_ $ text msg
     row (gap 10) $ do
-      button (SaveMessage "Hello" 12) Style.btnLight "Msg: Hello"
-      button (SaveMessage "This is Goodbye" 123) Style.btnLight "Msg: Goodbye"
-      button (SaveMessage "________" 0) Style.btnLight "Clear"
+      button (SaveMessage "Hello") Style.btnLight "Msg: Hello"
+      button (SaveMessage "Goodbye") Style.btnLight "Msg: Goodbye"
+      button (SaveMessage "________") Style.btnLight "Clear"

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -22,17 +22,21 @@ page = do
     pure $ col (pad 20 . gap 10) $ do
       el_ "Reload your browser after changing the settings below to see the session information preserved"
       row id $ do
-        hyper Contents $ viewContent clr msg
+        hyper (Contents (Woot 3) "hello bobby") $ viewContent clr msg
 
 
-data Contents = Contents
-  deriving (Generic, Param)
+data Contents = Contents Woot Text
+  deriving (Generic, ViewId)
+
+
+newtype Woot = Woot Int
+  deriving newtype (Param)
 
 
 data ContentsAction
   = SaveColor AppColor
-  | SaveMessage Text
-  deriving (Generic, Param)
+  | SaveMessage Text Int
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Contents where
@@ -44,7 +48,7 @@ content _ (SaveColor clr) = do
   setSession "color" clr
   msg <- session "msg"
   pure $ viewContent (Just clr) msg
-content _ (SaveMessage msg) = do
+content _ (SaveMessage msg _) = do
   setSession "msg" msg
   clr <- session "color"
   pure $ viewContent clr (Just msg)
@@ -75,6 +79,6 @@ viewMessage mm = do
     el (fontSize 24 . bold) "Session Message:"
     el_ $ text msg
     row (gap 10) $ do
-      button (SaveMessage "Hello") Style.btnLight "Msg: Hello"
-      button (SaveMessage "Goodbye") Style.btnLight "Msg: Goodbye"
-      button (SaveMessage "________") Style.btnLight "Clear"
+      button (SaveMessage "Hello" 12) Style.btnLight "Msg: Hello"
+      button (SaveMessage "This is Goodbye" 123) Style.btnLight "Msg: Goodbye"
+      button (SaveMessage "________" 0) Style.btnLight "Clear"

--- a/example/Example/Simple.hs
+++ b/example/Example/Simple.hs
@@ -25,11 +25,11 @@ simplePage = do
 
 
 data Message = Message Int
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data MessageAction = Louder Text
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Message where

--- a/example/Example/Transitions.hs
+++ b/example/Example/Transitions.hs
@@ -15,13 +15,13 @@ page = do
 
 
 data Contents = Contents
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data ContentsAction
   = Expand
   | Collapse
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Contents where

--- a/example/HelloWorld.hs
+++ b/example/HelloWorld.hs
@@ -4,7 +4,6 @@ import Data.Text (Text)
 import Web.Hyperbole
 
 
-
 main :: IO ()
 main = do
   run 3000 $ do
@@ -26,11 +25,11 @@ messageView m = do
 
 
 data Message = Message
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 
 data MessageAction = SetMessage Text
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 
 instance HyperView Message where

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -135,8 +135,9 @@ test-suite tests
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Test.ParamSpec
       Test.RouteSpec
-      Test.ViewSpec
+      Test.ViewActionSpec
       Paths_hyperbole
   autogen-modules:
       Paths_hyperbole

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -34,6 +34,7 @@ library
       Web.Hyperbole.Embed
       Web.Hyperbole.Forms
       Web.Hyperbole.HyperView
+      Web.Hyperbole.Param
       Web.Hyperbole.Route
       Web.Hyperbole.Session
       Web.Hyperbole.View

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -108,7 +108,9 @@ module Web.Hyperbole
     -- * Advanced
   , target
   , view
-  , Param (..)
+  , ViewId
+  , ViewAction
+  , Param
   , Response
 
     -- * Exports
@@ -141,6 +143,7 @@ import Web.Hyperbole.Effect
 import Web.Hyperbole.Embed
 import Web.Hyperbole.Forms (FormField, InputType (..), Validation (..), field, form, formField, input, invalidText, label, placeholder, submit, validate, validation)
 import Web.Hyperbole.HyperView
+import Web.Hyperbole.Param (Param)
 import Web.Hyperbole.Route
 import Web.Hyperbole.View
 

--- a/src/Web/Hyperbole/Effect.hs
+++ b/src/Web/Hyperbole/Effect.hs
@@ -20,6 +20,7 @@ import Network.HTTP.Types hiding (Query)
 import Web.FormUrlEncoded (Form, urlDecodeForm)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData (..), parseQueryParam)
 import Web.Hyperbole.HyperView
+import Web.Hyperbole.Param (Param (..))
 import Web.Hyperbole.Route
 import Web.Hyperbole.Session as Session
 import Web.View
@@ -196,8 +197,8 @@ getEvent = do
 parseEvent :: (HyperView id) => Query -> Maybe (Event id (Action id))
 parseEvent q = do
   Event ti ta <- lookupEvent q
-  vid <- parseParam ti
-  act <- parseParam ta
+  vid <- parseViewId ti
+  act <- parseAction ta
   pure $ Event vid act
 
 

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -43,7 +43,8 @@ import Text.Casing (kebab)
 import Web.FormUrlEncoded qualified as FE
 import Web.HttpApiData (FromHttpApiData (..))
 import Web.Hyperbole.Effect
-import Web.Hyperbole.HyperView (HyperView (..), Param (..), dataTarget)
+import Web.Hyperbole.HyperView (HyperView (..), ViewAction (..), ViewId (..), dataTarget)
+import Web.Hyperbole.Param (Param (..))
 import Web.Internal.FormUrlEncoded (FormOptions (..), GFromForm, defaultFormOptions, genericFromForm)
 import Web.View hiding (form, input, label)
 
@@ -52,14 +53,14 @@ import Web.View hiding (form, input, label)
 data FormFields id = FormFields id Validation
 
 
-instance (Param id) => Param (FormFields id) where
-  parseParam t = do
-    i <- parseParam t
+instance (ViewId id) => ViewId (FormFields id) where
+  parseViewId t = do
+    i <- parseViewId t
     pure $ FormFields i mempty
-  toParam (FormFields i _) = toParam i
+  toViewId (FormFields i _) = toViewId i
 
 
-instance (HyperView id, Param id) => HyperView (FormFields id) where
+instance (HyperView id, ViewId id) => HyperView (FormFields id) where
   type Action (FormFields id) = Action id
 
 
@@ -229,8 +230,8 @@ form a v f cnt = do
   -- let cnt = fcnt frm
   tag "form" (onSubmit a . dataTarget vid . f . flexCol) $ addContext (FormFields vid v) cnt
  where
-  onSubmit :: (Param a) => a -> Mod
-  onSubmit = att "data-on-submit" . toParam
+  onSubmit :: (ViewAction a) => a -> Mod
+  onSubmit = att "data-on-submit" . toAction
 
 
 -- | Button that submits the 'form'. Use 'button' to specify actions other than submit

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -2,14 +2,9 @@
 
 module Web.Hyperbole.HyperView where
 
-import Control.Applicative ((<|>))
-import Control.Monad (guard)
 import Data.Kind (Type)
-import Data.Text (Text, pack, unpack)
-import Data.Text qualified as T
-import GHC.Generics
-import Text.Read
 import Web.Hyperbole.Route (Route (..), routeUrl)
+import Web.Hyperbole.Param (Param(..))
 import Web.View
 
 
@@ -189,131 +184,6 @@ data Option opt id action = Option
   }
 
 
-{- | Types that can be serialized. 'HyperView' requires this for both its view id and action
-
-> data Message = Message Int
->   deriving (Generic, Param)
--}
-class Param a where
-  toParam :: a -> Text
-  default toParam :: (Generic a, GParam (Rep a)) => a -> Text
-  toParam = gToParam . from
-
-
-  -- not as flexible as FromHttpApiData, but derivable
-  parseParam :: Text -> Maybe a
-  default parseParam :: (Generic a, GParam (Rep a)) => Text -> Maybe a
-  parseParam t = to <$> gParseParam t
-
-
-class GParam f where
-  gToParam :: f p -> Text
-  gParseParam :: Text -> Maybe (f p)
-
-
-instance (GParam f, GParam g) => GParam (f :*: g) where
-  gToParam (a :*: b) = gToParam a <> "-" <> gToParam b
-  gParseParam t = do
-    let (at, bt) = breakSegment t
-    a <- gParseParam at
-    b <- gParseParam bt
-    pure $ a :*: b
-
-
-instance (GParam f, GParam g) => GParam (f :+: g) where
-  gToParam (L1 a) = gToParam a
-  gToParam (R1 b) = gToParam b
-  gParseParam t = do
-    (L1 <$> gParseParam @f t) <|> (R1 <$> gParseParam @g t)
-
-
--- do we add the datatypename? no, the constructor name
-instance (Datatype d, GParam f) => GParam (M1 D d f) where
-  gToParam (M1 a) = gToParam a
-  gParseParam t = M1 <$> gParseParam t
-
-
-instance (Constructor c, GParam f) => GParam (M1 C c f) where
-  gToParam (M1 a) =
-    let cn = toSegment (conName (undefined :: M1 C c f p))
-     in case gToParam a of
-          "" -> cn
-          t -> cn <> "-" <> t
-  gParseParam t = do
-    let (c, rest) = breakSegment t
-    guard $ c == toSegment (conName (undefined :: M1 C c f p))
-    M1 <$> gParseParam rest
-
-
-instance GParam U1 where
-  gToParam _ = ""
-  gParseParam _ = pure U1
-
-
-instance (GParam f) => GParam (M1 S s f) where
-  gToParam (M1 a) = gToParam a
-  gParseParam t = M1 <$> gParseParam t
-
-
-instance GParam (K1 R Text) where
-  gToParam (K1 t) = t
-  gParseParam t = pure $ K1 t
-
-
-instance GParam (K1 R String) where
-  gToParam (K1 s) = pack s
-  gParseParam t = pure $ K1 $ unpack t
-
-
-instance {-# OVERLAPPABLE #-} (Param a) => GParam (K1 R a) where
-  gToParam (K1 a) = toParam a
-  gParseParam t = K1 <$> parseParam t
-
-
--- instance {-# OVERLAPPABLE #-} (Show a, Read a) => GParam (K1 R a) where
---   gToParam (K1 a) = pack $ show a
---   gParseParam t = do
---     K1 <$> readMaybe (unpack t)
-
-breakSegment :: Text -> (Text, Text)
-breakSegment t =
-  let (start, rest) = T.breakOn "-" t
-   in (start, T.drop 1 rest)
-
-
-toSegment :: String -> Text
-toSegment = T.toLower . pack
-
-
--- instance (GParam f) => GParam (M1 C c f) where
---   gForm = M1 gForm
-
--- where
---  toDouble '\'' = '\"'
---  toDouble c = c
-
-instance (Param a) => Param (Maybe a) where
-  toParam Nothing = ""
-  toParam (Just a) = toParam a
-  parseParam "" = pure Nothing
-  parseParam t = Just $ parseParam t
-instance Param Integer where
-  toParam = pack . show
-  parseParam = readMaybe . unpack
-instance Param Float where
-  toParam = pack . show
-  parseParam = readMaybe . unpack
-instance Param Int where
-  toParam = pack . show
-  parseParam = readMaybe . unpack
-instance Param () where
-  toParam = pack . show
-  parseParam = readMaybe . unpack
-
-
-instance Param Text where
-  parseParam = pure
-  toParam = id
 
 
 {- | A hyperlink to another route

--- a/src/Web/Hyperbole/Param.hs
+++ b/src/Web/Hyperbole/Param.hs
@@ -35,7 +35,7 @@ class GParam f where
 instance (GParam f, GParam g) => GParam (f :*: g) where
   gToParam (a :*: b) = gToParam a <> "-" <> gToParam b
   gParseParam t = do
-    let (at, bt) = breakSegment t
+    let (at, bt) = breakSegment '-' t
     a <- gParseParam at
     b <- gParseParam bt
     pure $ a :*: b
@@ -61,7 +61,7 @@ instance (Constructor c, GParam f) => GParam (M1 C c f) where
           "" -> cn
           t -> cn <> "-" <> t
   gParseParam t = do
-    let (c, rest) = breakSegment t
+    let (c, rest) = breakSegment '-' t
     guard $ c == toSegment (conName (undefined :: M1 C c f p))
     M1 <$> gParseParam rest
 
@@ -86,9 +86,9 @@ instance {-# OVERLAPPABLE #-} (Param a) => GParam (K1 R a) where
 --   gParseParam t = do
 --     K1 <$> readMaybe (unpack t)
 
-breakSegment :: Text -> (Text, Text)
-breakSegment t =
-  let (start, rest) = T.breakOn "-" t
+breakSegment :: Char -> Text -> (Text, Text)
+breakSegment c t =
+  let (start, rest) = T.breakOn (pack [c]) t
    in (start, T.drop 1 rest)
 
 
@@ -129,6 +129,6 @@ instance Param String where
 
 
 -- | Easily derive Param for a type that implements HttpApiData with this and toQueryParam
-parseParamQuery :: FromHttpApiData a => Text -> Maybe a
+parseParamQuery :: (FromHttpApiData a) => Text -> Maybe a
 parseParamQuery t =
   either (const Nothing) Just $ parseQueryParam t

--- a/src/Web/Hyperbole/Param.hs
+++ b/src/Web/Hyperbole/Param.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DefaultSignatures #-}
+
+module Web.Hyperbole.Param where
+
+import Control.Applicative ((<|>))
+import Control.Monad (guard)
+import Data.Text (Text, pack)
+import Data.Text qualified as T
+import GHC.Generics
+import Web.HttpApiData
+
+
+{- | Types that can be serialized. 'HyperView' requires this for both its view id and action
+
+> data Message = Message Int
+>   deriving (Generic, Param)
+-}
+class Param a where
+  toParam :: a -> Text
+  default toParam :: (Generic a, GParam (Rep a)) => a -> Text
+  toParam = gToParam . from
+
+
+  -- not as flexible as FromHttpApiData, but derivable
+  parseParam :: Text -> Maybe a
+  default parseParam :: (Generic a, GParam (Rep a)) => Text -> Maybe a
+  parseParam t = to <$> gParseParam t
+
+
+class GParam f where
+  gToParam :: f p -> Text
+  gParseParam :: Text -> Maybe (f p)
+
+
+instance (GParam f, GParam g) => GParam (f :*: g) where
+  gToParam (a :*: b) = gToParam a <> "-" <> gToParam b
+  gParseParam t = do
+    let (at, bt) = breakSegment t
+    a <- gParseParam at
+    b <- gParseParam bt
+    pure $ a :*: b
+
+
+instance (GParam f, GParam g) => GParam (f :+: g) where
+  gToParam (L1 a) = gToParam a
+  gToParam (R1 b) = gToParam b
+  gParseParam t = do
+    (L1 <$> gParseParam @f t) <|> (R1 <$> gParseParam @g t)
+
+
+-- do we add the datatypename? no, the constructor name
+instance (Datatype d, GParam f) => GParam (M1 D d f) where
+  gToParam (M1 a) = gToParam a
+  gParseParam t = M1 <$> gParseParam t
+
+
+instance (Constructor c, GParam f) => GParam (M1 C c f) where
+  gToParam (M1 a) =
+    let cn = toSegment (conName (undefined :: M1 C c f p))
+     in case gToParam a of
+          "" -> cn
+          t -> cn <> "-" <> t
+  gParseParam t = do
+    let (c, rest) = breakSegment t
+    guard $ c == toSegment (conName (undefined :: M1 C c f p))
+    M1 <$> gParseParam rest
+
+
+instance GParam U1 where
+  gToParam _ = ""
+  gParseParam _ = pure U1
+
+
+instance (GParam f) => GParam (M1 S s f) where
+  gToParam (M1 a) = gToParam a
+  gParseParam t = M1 <$> gParseParam t
+
+
+instance {-# OVERLAPPABLE #-} (Param a) => GParam (K1 R a) where
+  gToParam (K1 a) = toParam a
+  gParseParam t = K1 <$> parseParam t
+
+
+-- instance {-# OVERLAPPABLE #-} (Show a, Read a) => GParam (K1 R a) where
+--   gToParam (K1 a) = pack $ show a
+--   gParseParam t = do
+--     K1 <$> readMaybe (unpack t)
+
+breakSegment :: Text -> (Text, Text)
+breakSegment t =
+  let (start, rest) = T.breakOn "-" t
+   in (start, T.drop 1 rest)
+
+
+toSegment :: String -> Text
+toSegment = T.toLower . pack
+
+
+-- instance (GParam f) => GParam (M1 C c f) where
+--   gForm = M1 gForm
+
+-- where
+--  toDouble '\'' = '\"'
+--  toDouble c = c
+
+instance (Param a) => Param (Maybe a) where
+  toParam Nothing = ""
+  toParam (Just a) = toParam a
+  parseParam "" = pure Nothing
+  parseParam t = Just $ parseParam t
+instance Param Integer where
+  toParam = toQueryParam
+  parseParam = parseParamQuery
+instance Param Float where
+  toParam = toQueryParam
+  parseParam = parseParamQuery
+instance Param Int where
+  toParam = toQueryParam
+  parseParam = parseParamQuery
+instance Param () where
+  toParam = toQueryParam
+  parseParam = parseParamQuery
+instance Param Text where
+  parseParam = parseParamQuery
+  toParam = toQueryParam
+instance Param String where
+  parseParam = parseParamQuery
+  toParam = toQueryParam
+
+
+-- | Easily derive Param for a type that implements HttpApiData with this and toQueryParam
+parseParamQuery :: FromHttpApiData a => Text -> Maybe a
+parseParamQuery t =
+  either (const Nothing) Just $ parseQueryParam t

--- a/test/Test/ParamSpec.hs
+++ b/test/Test/ParamSpec.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE OverloadedLists #-}
 
-module Test.ViewSpec where
+module Test.ParamSpec where
 
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics
 import Test.Syd
-import Web.Hyperbole.HyperView
+import Web.Hyperbole.Param
 import Web.View (att)
 import Web.View.Types
 
@@ -43,29 +43,28 @@ instance Param Custom where
 
 spec :: Spec
 spec = do
-  describe "HyperView" $ do
-    describe "Param" $ do
-      describe "toParam" $ do
-        it "basic" $ toParam Thing `shouldBe` "thing"
-        it "custom" $ toParam Custom `shouldBe` "something"
+  describe "Param" $ do
+    describe "toParam" $ do
+      it "basic" $ toParam Thing `shouldBe` "thing"
+      it "custom" $ toParam Custom `shouldBe` "something"
 
-      describe "parseParam" $ do
-        it "basic" $ parseParam "thing" `shouldBe` Just Thing
-        it "basic lowercase" $ parseParam @Thing "Thing" `shouldBe` Nothing
-        it "custom" $ parseParam "something" `shouldBe` Just Custom
-        it "custom other" $ parseParam @Thing "custom" `shouldBe` Nothing
+    describe "parseParam" $ do
+      it "basic" $ parseParam "thing" `shouldBe` Just Thing
+      it "basic lowercase" $ parseParam @Thing "Thing" `shouldBe` Nothing
+      it "custom" $ parseParam "something" `shouldBe` Just Custom
+      it "custom other" $ parseParam @Thing "custom" `shouldBe` Nothing
 
-      describe "has-string" $ do
-        it "should not contain single quotes" $ do
-          toParam (HasString "woot") `shouldNotSatisfy` containsSingleQuotes
+    describe "has-string" $ do
+      it "should not contain single quotes" $ do
+        toParam (HasString "woot") `shouldNotSatisfy` containsSingleQuotes
 
-        it "should roundtrip" $ do
-          let inp = HasString "woot"
-          parseParam (toParam inp) `shouldBe` Just inp
+      it "should roundtrip" $ do
+        let inp = HasString "woot"
+        parseParam (toParam inp) `shouldBe` Just inp
 
-      describe "compound" $ do
-        it "should toparam" $ toParam (Two Thing) `shouldBe` "two-thing"
-        it "double roundtrip" $ parseParam (toParam (Two Thing)) `shouldBe` Just (Two Thing)
+    describe "compound" $ do
+      it "should toparam" $ toParam (Two Thing) `shouldBe` "two-thing"
+      it "double roundtrip" $ parseParam (toParam (Two Thing)) `shouldBe` Just (Two Thing)
 
   describe "Param Attributes" $ do
     it "should serialize basic id" $ do

--- a/test/Test/ViewActionSpec.hs
+++ b/test/Test/ViewActionSpec.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedLists #-}
+
+module Test.ViewActionSpec where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Generics
+import Test.Syd
+import Web.Hyperbole.HyperView
+import Web.View (att)
+import Web.View.Types
+
+
+data Simple = Simple
+  deriving (Generic, Eq, Show, ViewAction)
+
+
+data Product = Product String Int
+  deriving (Generic, Show, Eq, ViewAction, Read)
+
+
+data Product' = Product' HasText Int
+  deriving (Generic, Show, Eq, ViewAction, Read)
+
+
+data Sum
+  = SumA
+  | SumB Int
+  deriving (Generic, Show, Eq, ViewAction)
+
+
+data Compound = Compound Product
+  deriving (Generic, Show, Eq, ViewAction)
+
+
+data HasText = HasText Text
+  deriving (Generic, Show, Eq, ViewAction, Read)
+
+
+-- data Compound
+--   = One
+--   | Two Thing
+--   | WithId (Id Thing)
+--   deriving (Generic, Param, Show, Eq)
+--
+--
+-- newtype Id a = Id {fromId :: Text}
+--   deriving newtype (Param, Eq, Ord)
+--   deriving (Generic, Show)
+--
+--
+-- instance Param Custom where
+--   toParam Custom = "something"
+--   parseParam "something" = Just Custom
+--   parseParam _ = Nothing
+
+spec :: Spec
+spec = do
+  describe "ViewAction" $ do
+    describe "toAction" $ do
+      it "simple" $ toAction Simple `shouldBe` "Simple"
+      it "has text" $ toAction (HasText "hello world") `shouldBe` "HasText \"hello world\""
+      it "product" $ toAction (Product "hello world" 123) `shouldBe` "Product \"hello world\" 123"
+      it "sum" $ toAction (SumB 123) `shouldBe` "SumB 123"
+      it "compound" $ toAction (Compound (Product "hello world" 123)) `shouldBe` "Compound (Product \"hello world\" 123)"
+
+    describe "parseAction" $ do
+      it "simple" $ parseAction "Simple" `shouldBe` Just Simple
+
+    describe "roundTrip" $ do
+      it "simple" $ do
+        parseAction (toAction Simple) `shouldBe` Just Simple
+      it "has text multiple words" $ do
+        let a = HasText "hello world"
+        parseAction (toAction a) `shouldBe` Just a
+      it "product" $ do
+        let a = Product "hello world" 123
+        parseAction (toAction a) `shouldBe` Just a
+      it "product'" $ do
+        let a = Product' (HasText "hello world") 123
+        parseAction (toAction a) `shouldBe` Just a
+      it "compound" $ do
+        let a = Compound (Product "hello world" 123)
+        parseAction (toAction a) `shouldBe` Just a
+      it "sum" $ do
+        let a = SumB 123
+        parseAction (toAction a) `shouldBe` Just a


### PR DESCRIPTION
Deriving `ViewAction` and `ViewId` instead of `Param`. Allows the id to focus on looking like a simple identifier and the action to focus on preserving complicated structures (and looking like a Show instance)