### PR TITLE
Forms typed validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Create fully interactive HTML applications with type-safe serverside Haskell. In
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 
+import Data.Text (Text)
 import Web.Hyperbole
 
 main = do
@@ -29,10 +30,10 @@ mainPage = do
 
 
 data Message = Message Int
-  deriving (Generic, Param)
+  deriving (Generic, ViewId)
 
 data MessageAction = Louder Text
-  deriving (Generic, Param)
+  deriving (Generic, ViewAction)
 
 instance HyperView Message where
   type Action Message = MessageAction

--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -151,18 +151,18 @@ contactView u = do
 
 
 contactEdit :: User -> View Contact ()
-contactEdit u =
+contactEdit u = do
   onRequest loading $ do
-    form Save mempty (pad 10 . gap 10) $ do
-      field @FirstName fld id $ do
+    form @[FirstName, LastName, Age] Save mempty (pad 10 . gap 10) $ do
+      field @FirstName (const fld) $ do
         label "First Name:"
         input Name (value u.firstName)
 
-      field @LastName fld id $ do
+      field @LastName (const fld) $ do
         label "Last Name:"
         input Name (value u.lastName)
 
-      field @Age fld id $ do
+      field @Age (const fld) $ do
         label "Age:"
         input Number (value $ cs $ show u.age)
 

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -59,6 +59,7 @@ library
     , casing >0.1 && <0.2
     , containers >=0.6 && <1
     , cookie ==0.4.*
+    , data-diverse
     , effectful >=2.3 && <3
     , file-embed >=0.0.10 && <0.1
     , http-api-data ==0.6.*
@@ -104,6 +105,7 @@ test-suite test
     , casing >0.1 && <0.2
     , containers >=0.6 && <1
     , cookie ==0.4.*
+    , data-diverse
     , effectful >=2.3 && <3
     , file-embed >=0.0.10 && <0.1
     , http-api-data ==0.6.*

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -71,7 +71,7 @@ library
     , wai >=3.2 && <4
     , wai-websockets >=3.0 && <4
     , warp >=3.3 && <4
-    , web-view >=0.4 && <=0.5
+    , web-view >=0.4 && <=0.6
     , websockets >=0.12 && <0.14
   default-language: GHC2021
 
@@ -119,6 +119,6 @@ test-suite test
     , wai >=3.2 && <4
     , wai-websockets >=3.0 && <4
     , warp >=3.3 && <4
-    , web-view >=0.4 && <=0.5
+    , web-view >=0.4 && <=0.6
     , websockets >=0.12 && <0.14
   default-language: GHC2021

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           hyperbole
-version:        0.3.6
+version:        0.4.0
 synopsis:       Interactive HTML apps using type-safe serverside Haskell
 description:    Interactive HTML applications using type-safe serverside Haskell. Inspired by HTMX, Elm, and Phoenix LiveView
 category:       Web, Network

--- a/package.yaml
+++ b/package.yaml
@@ -46,7 +46,7 @@ dependencies:
   - http-types >= 0.12 && <0.13
   - wai >= 3.2 && <4
   - warp >= 3.3 && <4
-  - web-view >= 0.4 && <=0.5
+  - web-view >= 0.4 && <=0.6
   - string-conversions >= 0.4 && <0.5
   - wai-websockets >= 3.0 && <4
   - network >= 3.1 && <4

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:               hyperbole
-version:            0.3.6
+version:            0.4.0
 synopsis:           Interactive HTML apps using type-safe serverside Haskell
 homepage:           https://github.com/seanhess/hyperbole
 github:             seanhess/hyperbole

--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ dependencies:
   - network >= 3.1 && <4
   - websockets >= 0.12 && <0.14
   - cookie >=0.4 && <0.5
+  - data-diverse
 
 library:
   source-dirs: src

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -34,6 +34,7 @@ module Web.Hyperbole
   , routeRequest -- maybe belongs in an application section
   , Route
   , routeUrl
+  , routePath
   , route
 
     -- * Pages

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -81,7 +81,8 @@ module Web.Hyperbole
   , formField
 
     -- ** Validation
-  , Validation (..)
+  , Validation
+  , Validation' (..)
   , Validated (..)
   , validate
   , validation

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -81,9 +81,13 @@ module Web.Hyperbole
 
     -- ** Validation
   , Validation (..)
+  , Validated (..)
   , validate
   , validation
+  , fieldValid
+  , validateWith
   , invalidText
+  , anyInvalid
 
     -- * Hyperbole Effect
   , Hyperbole
@@ -135,13 +139,12 @@ module Web.Hyperbole
   ) where
 
 import Effectful (Eff, (:>))
-import GHC.Generics (Generic)
 import Network.Wai (Application)
 import Network.Wai.Handler.Warp as Warp (run)
 import Web.Hyperbole.Application
 import Web.Hyperbole.Effect
 import Web.Hyperbole.Embed
-import Web.Hyperbole.Forms (FormField, InputType (..), Validation (..), field, form, formField, input, invalidText, label, placeholder, submit, validate, validation)
+import Web.Hyperbole.Forms
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.Route
 import Web.Hyperbole.View

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -17,6 +17,7 @@ module Web.Hyperbole.Forms
   , formField
   , formFields
   , Form (..)
+  , Field (..)
   , defaultFormOptions
   , FormOptions (..)
   , Validation (..)
@@ -35,7 +36,6 @@ module Web.Hyperbole.Forms
   )
 where
 
-import Data.Functor.Identity (Identity)
 import Data.Kind (Constraint, Type)
 import Data.Text (Text, pack)
 import Effectful
@@ -281,7 +281,8 @@ submit f = tag "button" (att "type" "submit" . f)
 -- type instance Field' Label a = Text
 -- type instance Field' Invalid a = Maybe Text
 
-newtype Field a = Field a
+-- | Generic FormField type for parsing record-based forms
+newtype Field a = Field {value :: a}
 
 
 formFields :: forall form es. (Form form, Hyperbole :> es) => Eff es form
@@ -359,7 +360,7 @@ instance (GForm f) => GForm (M1 C c f) where
   gFormParse f = M1 <$> gFormParse f
 
 
-instance (Selector s, GForm f) => GForm (M1 S s f) where
+instance {-# OVERLAPPABLE #-} (Selector s, GForm f) => GForm (M1 S s f) where
   gFormParse f = M1 <$> gFormParse f
 
 
@@ -466,14 +467,14 @@ type family ElemGo e es orig :: Constraint where
 -- data FakeField = FakeField Text deriving (Generic, FormField)
 --
 --
--- type UserFields = [User, Age, Pass1, Pass2]
---
+-- -- type UserFields = [User, Age, Pass1, Pass2]
 --
 -- data UserForm = UserForm
 --   { user :: User
 --   , age :: Age
 --   , pass1 :: Pass1
 --   , pass2 :: Pass2
+--   , woot :: Field Text
 --   }
 --   deriving (Generic, Form)
 

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -55,15 +55,15 @@ import Web.View hiding (form, input, label)
 data FormFields id fs = FormFields id (Validation fs)
 
 
-instance (ViewId id) => ViewId (FormFields id) where
+instance (ViewId id) => ViewId (FormFields id fs) where
   parseViewId t = do
     i <- parseViewId t
     pure $ FormFields i mempty
   toViewId (FormFields i _) = toViewId i
 
 
-instance (HyperView id, ViewId id) => HyperView (FormFields id) where
-  type Action (FormFields id) = Action id
+instance (HyperView id, ViewId id) => HyperView (FormFields id fs) where
+  type Action (FormFields id fs) = Action id
 
 
 -- | Choose one for 'input's to give the browser autocomplete hints
@@ -111,7 +111,7 @@ formAction _ SignUp = do
 
 -- would be easier if you pass in your own data. Right now everything is indexed by type
 data Validated fs a = Invalid Text | NotInvalid | Valid
-  deriving Show
+  deriving (Show)
 
 
 instance Semigroup (Validated fs a) where
@@ -120,6 +120,7 @@ instance Semigroup (Validated fs a) where
   Valid <> _ = Valid
   _ <> Valid = Valid
   a <> _ = a
+
 
 instance Monoid (Validated fs a) where
   mempty = NotInvalid
@@ -132,7 +133,7 @@ newtype Validation (fs :: [Type]) = Validation [(Text, Validated fs ())]
 
 -- TODO: constraint Elem a fs
 validation :: forall a fs. (FormField a) => Validation fs -> Validated fs a
-validation (Validation vs) = mconcat $ fmap (convert . snd) $ filter ((==inputName @a) . fst) vs
+validation (Validation vs) = mconcat $ fmap (convert . snd) $ filter ((== inputName @a) . fst) vs
 
 
 convert :: Validated fs a -> Validated fs b


### PR DESCRIPTION
The Forms in 0.3 didn't support a "Known to be Valid" state, which is required for my app. This design is common in signup forms, when you confirm that a username is available, and the field turns green. 

This branch expands the `Validated` options into the following. It also supports type-based indexing on the Validation type, using type-level lists. So forms now know which fields they contain, based on that type-level list, and the Validation must match. See [Example.Forms](https://github.com/seanhess/hyperbole/blob/fc427e2ab8a529c12231ead2a3bb9505acc8cf44/example/Example/Forms.hs)

```
data Validated fs a = Invalid Text | NotInvalid | Valid
  deriving (Show)

newtype Validation (fs :: [Type]) = Validation [(Text, Validated fs ())]
  deriving newtype (Semigroup, Monoid, Show)
```

I also changed the `Mod` for `field` to `(Validated fs a -> Mod)`, which makes it easy to customize the style for the entire field at once based on the state. It makes it slightly less easy to set default styles on the field, but those can also be set on a nested container or the input itself. Accessing the `Validated fs a` for the field otherwise requires calling `fieldValid`. 

@kfigiela Have you played with forms yet? I'd love some feedback: I'm unsure about the design. It supports many use-cases, but I wish that the validation states were customizable / composable (not easy to do without complicating the types significantly). 