### PR TITLE
Add dev environment with nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist-newstyle
 .DS_Store
 tags
 node_modules
+# Auto-generated pre-commit config
+.pre-commit-config.yaml
+# Nix output dir
+result

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hyperbole
 =========
 
-[![Hackage](https://img.shields.io/hackage/v/hyperbole.svg)](https://hackage.haskell.org/package/hyperbole) 
+[![Hackage](https://img.shields.io/hackage/v/hyperbole.svg)](https://hackage.haskell.org/package/hyperbole)
 
 Create fully interactive HTML applications with type-safe serverside Haskell. Inspired by [HTMX](https://htmx.org/), [Elm](https://elm-lang.org/), and [Phoenix LiveView](https://www.phoenixframework.org/)
 
@@ -88,6 +88,17 @@ Local Development
 -----------------
 
 ### Dependencies
+
+#### With nix
+
+With nix installed, you can use `nix develop` to get a shell with all dependencies installed.
+
+Tip:
+If you have `direnv` as well, you can run `direnv allow` once and every time you open a shell in this directory, it will automatically load the environment.
+
+```
+
+#### Manual dependency installation
 
 Download and install [NPM](https://nodejs.org/en/download). On a mac, can be installed via homebrew:
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
+tests: True
 packages:
   .

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2140,6 +2140,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,151 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720031269,
+        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1718811006,
+        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,79 @@
+{
+  description = "A flake for hyperbole development";
+
+  inputs = {
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        packageName = "hyperbole";
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        haskellPackages = pkgs.haskellPackages.override {
+          overrides = self: super: {
+            # Tests for web-view version 0.4.0 are broken, so we disable them
+            web-view =
+              pkgs.haskell.lib.dontCheck (super.callHackageDirect
+                {
+                  pkg = "web-view";
+                  ver = "0.4.0";
+                  sha256 = "sha256-ug5pduRQEfgcKRCDNP/UmGS3jGNVKlSPrDk06Dp6sYc=";
+                }
+                { });
+
+            http-api-data =
+              pkgs.haskell.lib.doJailbreak (super.callHackageDirect
+                {
+                  pkg = "http-api-data";
+                  ver = "0.6.1";
+                  sha256 = "sha256-WKXZcCW5+l4caZcZMG6gNFe6y4WMigit5w1WgShmeZk=";
+                }
+                { });
+
+          };
+        };
+      in
+      {
+        packages.default = self.packages.${system}.${packageName};
+        packages.${packageName} =
+          haskellPackages.callCabal2nix packageName self { };
+
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              # TODO: hlint is currently failing. Fix hints.
+              # hlint.enable = true;
+              hpack.enable = true;
+              # TODO: fourmolu is currently failing. Fix formatting.
+              # fourmolu.enable = true;
+              nixpkgs-fmt.enable = true;
+            };
+          };
+        };
+
+        devShells.default = pkgs.haskellPackages.shellFor rec {
+          inherit (self.checks.${system}.pre-commit-check) shellHook;
+
+          packages = p: [ self.packages.${system}.${packageName} ];
+
+          # Programs that will be available in the development shell
+          buildInputs = with pkgs; [
+            nodePackages_latest.webpack-cli
+            haskellPackages.cabal-install
+            haskellPackages.haskell-language-server
+            haskellPackages.fourmolu
+            ghciwatch
+            hpack
+          ];
+
+          # Ensure that libz.so and other libraries are available to TH
+          # splices, cabal repl, etc.
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+        };
+      });
+}


### PR DESCRIPTION
Closes https://github.com/seanhess/hyperbole/issues/17, but feel free to reject it if you don't want this in the repo.

The environment provides:
- `ghc-9.6.5`
- `cabal-install`
- a compatible `haskell-language-server` executable 
- `hpack`
- `fourmolu`
- `hlint`
- `webpack`
- `direnv` integration to eliminate the need to enter a development environment manually with `nix develop`
- `pre-commit-hooks` that check that there are no formatting or linting issues automatically before commits


See the issue for more information and feel free to ask me anything!