### PR TITLE
Extract functionality into their own modules

### DIFF
--- a/example/hyperbole-examples.cabal
+++ b/example/hyperbole-examples.cabal
@@ -27,9 +27,14 @@ executable examples
       Web.Hyperbole
       Web.Hyperbole.Application
       Web.Hyperbole.Effect
+      Web.Hyperbole.Effect.Server
       Web.Hyperbole.Embed
+      Web.Hyperbole.Event
       Web.Hyperbole.Forms
+      Web.Hyperbole.Host
       Web.Hyperbole.HyperView
+      Web.Hyperbole.Request
+      Web.Hyperbole.Response
       Web.Hyperbole.Route
       Web.Hyperbole.Session
       Web.Hyperbole.View

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -31,9 +31,14 @@ library
       Web.Hyperbole
       Web.Hyperbole.Application
       Web.Hyperbole.Effect
+      Web.Hyperbole.Effect.Server
       Web.Hyperbole.Embed
+      Web.Hyperbole.Event
       Web.Hyperbole.Forms
+      Web.Hyperbole.Host
       Web.Hyperbole.HyperView
+      Web.Hyperbole.Request
+      Web.Hyperbole.Response
       Web.Hyperbole.Route
       Web.Hyperbole.Session
       Web.Hyperbole.View

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -148,6 +148,7 @@ import Web.Hyperbole.Effect
 import Web.Hyperbole.Embed
 import Web.Hyperbole.Forms
 import Web.Hyperbole.HyperView
+import Web.Hyperbole.Response (Response)
 import Web.Hyperbole.Route
 import Web.Hyperbole.View
 

--- a/src/Web/Hyperbole/Application.hs
+++ b/src/Web/Hyperbole/Application.hs
@@ -8,37 +8,34 @@ module Web.Hyperbole.Application
   , liveApp
   , socketApp
   , runServerSockets
-  , runServerWai
   , basicDocument
   , routeRequest
   ) where
 
 import Control.Monad (forever)
-import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
-import Data.List qualified as L
 import Data.Maybe (fromMaybe)
 import Data.String.Conversions (cs)
 import Data.String.Interpolate (i)
-import Data.Text (Text, pack)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Effectful
 import Effectful.Concurrent.Async
 import Effectful.Dispatch.Dynamic
 import Effectful.Error.Static
-import Effectful.State.Static.Local
-import Network.HTTP.Types (HeaderName, Method, parseQuery, status200, status400, status401, status404, status500)
+import Network.HTTP.Types (parseQuery)
 import Network.Wai qualified as Wai
 import Network.Wai.Handler.WebSockets (websocketsOr)
-import Network.Wai.Internal (ResponseReceived (..))
 import Network.WebSockets (Connection, PendingConnection, defaultConnectionOptions)
 import Network.WebSockets qualified as WS
 import Web.Cookie (parseCookies)
 import Web.Hyperbole.Effect
+import Web.Hyperbole.Effect.Server (Server (..), SocketError (..), runServerSockets, runServerWai)
 import Web.Hyperbole.Embed (cssResetEmbed, scriptEmbed)
+import Web.Hyperbole.Host (Host (..))
+import Web.Hyperbole.Request (Request (..))
+import Web.Hyperbole.Response (Response (..))
 import Web.Hyperbole.Route
-import Web.Hyperbole.Session
-import Web.View (View, renderLazyByteString, renderUrl)
 
 
 {- | Turn one or more 'Page's into a Wai Application. Respond using both HTTP and WebSockets
@@ -78,151 +75,6 @@ waiApp toDoc actions req res = do
     Just r -> pure r
 
 
-errNotHandled :: Event Text Text -> String
-errNotHandled ev =
-  L.intercalate
-    "\n"
-    [ "No Handler for Event viewId: " <> cs ev.viewId <> " action: " <> cs ev.action
-    , "<p>Remember to add a `hyper` handler in your page function</p>"
-    , "<pre>"
-    , "page :: (Hyperbole :> es) => Page es Response"
-    , "page = do"
-    , "  handle contentsHandler"
-    , "  load $ do"
-    , "    pure $ hyper Contents contentsView"
-    , "</pre>"
-    ]
-
-
-runServerWai
-  :: (IOE :> es)
-  => (BL.ByteString -> BL.ByteString)
-  -> Wai.Request
-  -> (Wai.Response -> IO ResponseReceived)
-  -> Eff (Server : es) a
-  -> Eff es (Maybe Wai.ResponseReceived)
-runServerWai toDoc req respond =
-  reinterpret runLocal $ \_ -> \case
-    LoadRequest -> do
-      fromWaiRequest req
-    SendResponse sess r -> do
-      rr <- liftIO $ sendResponse sess r
-      put (Just rr)
- where
-  runLocal :: (IOE :> es) => Eff (State (Maybe ResponseReceived) : es) a -> Eff es (Maybe ResponseReceived)
-  runLocal = execState Nothing
-
-  sendResponse :: Session -> Response -> IO Wai.ResponseReceived
-  sendResponse sess r =
-    respond $ response r
-   where
-    response :: Response -> Wai.Response
-    response NotFound = respError status404 "Not Found"
-    response Empty = respError status500 "Empty Response"
-    response (Err (ErrParse e)) = respError status400 ("Parse Error: " <> cs e)
-    response (Err (ErrParam e)) = respError status400 $ "ErrParam: " <> cs e
-    response (Err (ErrOther e)) = respError status500 $ "Server Error: " <> cs e
-    response (Err ErrAuth) = respError status401 "Unauthorized"
-    response (Err (ErrNotHandled e)) = respError status400 $ cs $ errNotHandled e
-    response (Response _ vw) =
-      respHtml $
-        addDocument (Wai.requestMethod req) (renderLazyByteString vw)
-    response (Redirect u) = do
-      let url = renderUrl u
-      -- We have to use a 200 javascript redirect because javascript
-      -- will redirect the fetch(), while we want to redirect the whole page
-      -- see index.ts sendAction()
-      let headers = ("Location", cs url) : contentType ContentHtml : setCookies
-      Wai.responseLBS status200 headers $ "<script>window.location = '" <> cs url <> "'</script>"
-
-    respError s = Wai.responseLBS s [contentType ContentText]
-
-    respHtml body =
-      -- always set the session...
-      let headers = contentType ContentHtml : setCookies
-       in Wai.responseLBS status200 headers body
-
-    setCookies =
-      [("Set-Cookie", sessionSetCookie sess)]
-
-  -- convert to document if full page request. Subsequent POST requests will only include fragments
-  addDocument :: Method -> BL.ByteString -> BL.ByteString
-  addDocument "GET" bd = toDoc bd
-  addDocument _ bd = bd
-
-  fromWaiRequest :: (MonadIO m) => Wai.Request -> m Request
-  fromWaiRequest wr = do
-    body <- liftIO $ Wai.consumeRequestBodyLazy wr
-    let path = Wai.pathInfo wr
-        query = Wai.queryString wr
-        headers = Wai.requestHeaders wr
-        cookie = fromMaybe "" $ L.lookup "Cookie" headers
-        host = Host $ fromMaybe "" $ L.lookup "Host" headers
-        cookies = parseCookies cookie
-        method = Wai.requestMethod wr
-    pure $ Request{body, path, query, method, cookies, host}
-
-
-runServerSockets
-  :: (IOE :> es)
-  => Connection
-  -> Request
-  -> Eff (Server : es) Response
-  -> Eff es Response
-runServerSockets conn req = reinterpret runLocal $ \_ -> \case
-  LoadRequest -> pure req -- receiveRequest conn
-  SendResponse sess res -> do
-    case res of
-      (Response vid vw) -> sendView (sessionMeta sess) vid vw
-      (Err r) -> sendError r
-      Empty -> sendError $ ErrOther "Empty"
-      NotFound -> sendError $ ErrOther "NotFound"
-      (Redirect url) -> sendRedirect (sessionMeta sess) url
- where
-  runLocal = runErrorNoCallStackWith @SocketError onSocketError
-
-  onSocketError :: (IOE :> es) => SocketError -> Eff es Response
-  onSocketError e = do
-    let r = ErrOther $ cs $ show e
-    sendError r
-    pure $ Err r
-
-  sendMessage :: (MonadIO m) => Metadata -> BL.ByteString -> m ()
-  sendMessage meta cnt = do
-    let msg = renderMetadata meta <> "\n" <> cnt
-    liftIO $ WS.sendTextData conn msg
-
-  sendError :: (IOE :> es) => ResponseError -> Eff es ()
-  sendError r = do
-    -- TODO: better error handling!
-    sendMessage (metadata "ERROR" (pack (show r))) ""
-
-  sendView :: (IOE :> es) => Metadata -> TargetViewId -> View () () -> Eff es ()
-  sendView meta vid vw = do
-    sendMessage (viewIdMeta vid <> meta) (renderLazyByteString vw)
-
-  renderMetadata :: Metadata -> BL.ByteString
-  renderMetadata (Metadata m) = BL.intercalate "\n" $ fmap (uncurry metaLine) m
-
-  sendRedirect :: (IOE :> es) => Metadata -> Url -> Eff es ()
-  sendRedirect meta u = do
-    -- conn <- ask @Connection
-    let r = metadata "REDIRECT" (renderUrl u)
-    sendMessage (r <> meta) ""
-
-  sessionMeta :: Session -> Metadata
-  sessionMeta sess = Metadata [("SESSION", cs (sessionSetCookie sess))]
-
-  viewIdMeta :: TargetViewId -> Metadata
-  viewIdMeta (TargetViewId vid) = Metadata [("VIEW-ID", cs vid)]
-
-  metadata :: BL.ByteString -> Text -> Metadata
-  metadata name value = Metadata [(name, value)]
-
-  metaLine :: BL.ByteString -> Text -> BL.ByteString
-  metaLine name value = "|" <> name <> "|" <> cs value
-
-
 receiveRequest :: (IOE :> es, Error SocketError :> es) => Connection -> Eff es Request
 receiveRequest conn = do
   t <- receiveText conn
@@ -244,12 +96,6 @@ parseMessage t = do
     [url, host, cook] -> parse url cook host Nothing
     _ -> Left $ InvalidMessage t
  where
-  parseUrl :: Text -> Either SocketError (Text, Text)
-  parseUrl u =
-    case T.splitOn "?" u of
-      [url, query] -> pure (url, query)
-      _ -> Left $ InvalidMessage u
-
   parse :: Text -> Text -> Text -> Maybe Text -> Either SocketError Request
   parse url cook hst mbody = do
     (u, q) <- parseUrl url
@@ -261,29 +107,16 @@ parseMessage t = do
         body = cs $ fromMaybe "" mbody
     pure $ Request{path, host, query, body, method, cookies}
 
+  parseUrl :: Text -> Either SocketError (Text, Text)
+  parseUrl u =
+    case T.splitOn "?" u of
+      [url, query] -> pure (url, query)
+      _ -> Left $ InvalidMessage u
+
   paths p = filter (/= "") $ T.splitOn "/" p
 
   -- drop up to the colon, then ': '
   header = T.drop 2 . T.dropWhile (/= ':')
-
-
-newtype Metadata = Metadata [(BL.ByteString, Text)]
-  deriving newtype (Semigroup, Monoid)
-
-
-data SocketError
-  = InvalidMessage Text
-  deriving (Show, Eq)
-
-
-data ContentType
-  = ContentHtml
-  | ContentText
-
-
-contentType :: ContentType -> (HeaderName, BS.ByteString)
-contentType ContentHtml = ("Content-Type", "text/html; charset=utf-8")
-contentType ContentText = ("Content-Type", "text/plain; charset=utf-8")
 
 
 {- | wrap HTML fragments in a simple document with a custom title and include required embeds
@@ -306,14 +139,14 @@ You may want to specify a custom document function instead:
 >   </html>|]
 -}
 basicDocument :: Text -> BL.ByteString -> BL.ByteString
-basicDocument title cnt =
+basicDocument title content =
   [i|<html>
       <head>
         <title>#{title}</title>
         <script type="text/javascript">#{scriptEmbed}</script>
         <style type type="text/css">#{cssResetEmbed}</style>
       </head>
-      <body>#{cnt}</body>
+      <body>#{content}</body>
   </html>|]
 
 

--- a/src/Web/Hyperbole/Effect/Server.hs
+++ b/src/Web/Hyperbole/Effect/Server.hs
@@ -1,0 +1,205 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+module Web.Hyperbole.Effect.Server
+  ( Server (..)
+  , runServerWai
+  , runServerSockets
+  , SocketError (..)
+  ) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import Data.List qualified as L
+import Data.Maybe (fromMaybe)
+import Data.String.Conversions (cs)
+import Data.Text (Text, pack)
+import Effectful
+import Effectful.Dispatch.Dynamic
+import Effectful.Error.Static
+import Effectful.State.Static.Local
+import Network.HTTP.Types (HeaderName, Method, status200, status400, status401, status404, status500)
+import Network.Wai qualified as Wai
+import Network.Wai.Internal (ResponseReceived (..))
+import Network.WebSockets (Connection)
+import Network.WebSockets qualified as WS
+import Web.Cookie (parseCookies)
+import Web.Hyperbole.Event (Event (..))
+import Web.Hyperbole.Host (Host (..))
+import Web.Hyperbole.Request (Request (..))
+import Web.Hyperbole.Response (Response (..), ResponseError (..), TargetViewId (..))
+import Web.Hyperbole.Session as Session
+import Web.View (Url, View, renderLazyByteString, renderUrl)
+
+
+-- | Low level effect mapping request/response to either HTTP or WebSockets
+data Server :: Effect where
+  LoadRequest :: Server m Request
+  SendResponse :: Session -> Response -> Server m ()
+
+
+type instance DispatchOf Server = 'Dynamic
+
+
+runServerWai
+  :: (IOE :> es)
+  => (BL.ByteString -> BL.ByteString)
+  -> Wai.Request
+  -> (Wai.Response -> IO ResponseReceived)
+  -> Eff (Server : es) a
+  -> Eff es (Maybe Wai.ResponseReceived)
+runServerWai toDoc req respond =
+  reinterpret runLocal $ \_ -> \case
+    LoadRequest -> fromWaiRequest req
+    SendResponse sess r -> do
+      rr <- liftIO $ sendResponse sess r
+      put (Just rr)
+ where
+  runLocal :: (IOE :> es) => Eff (State (Maybe ResponseReceived) : es) a -> Eff es (Maybe ResponseReceived)
+  runLocal = execState Nothing
+
+  sendResponse :: Session -> Response -> IO Wai.ResponseReceived
+  sendResponse sess r =
+    respond $ response r
+   where
+    response :: Response -> Wai.Response
+    response NotFound = respError status404 "Not Found"
+    response Empty = respError status500 "Empty Response"
+    response (Err (ErrParse e)) = respError status400 ("Parse Error: " <> cs e)
+    response (Err (ErrParam e)) = respError status400 $ "ErrParam: " <> cs e
+    response (Err (ErrOther e)) = respError status500 $ "Server Error: " <> cs e
+    response (Err ErrAuth) = respError status401 "Unauthorized"
+    response (Err (ErrNotHandled e)) = respError status400 $ cs $ errNotHandled e
+    response (Response _ vw) =
+      respHtml $
+        addDocument (Wai.requestMethod req) (renderLazyByteString vw)
+    response (Redirect u) = do
+      let url = renderUrl u
+      -- We have to use a 200 javascript redirect because javascript
+      -- will redirect the fetch(), while we want to redirect the whole page
+      -- see index.ts sendAction()
+      let headers = ("Location", cs url) : contentType ContentHtml : setCookies
+      Wai.responseLBS status200 headers $ "<script>window.location = '" <> cs url <> "'</script>"
+
+    respError s = Wai.responseLBS s [contentType ContentText]
+
+    respHtml body =
+      -- always set the session...
+      let headers = contentType ContentHtml : setCookies
+       in Wai.responseLBS status200 headers body
+
+    setCookies =
+      [("Set-Cookie", sessionSetCookie sess)]
+
+  -- convert to document if full page request. Subsequent POST requests will only include fragments
+  addDocument :: Method -> BL.ByteString -> BL.ByteString
+  addDocument "GET" bd = toDoc bd
+  addDocument _ bd = bd
+
+  fromWaiRequest :: (MonadIO m) => Wai.Request -> m Request
+  fromWaiRequest wr = do
+    body <- liftIO $ Wai.consumeRequestBodyLazy wr
+    let path = Wai.pathInfo wr
+        query = Wai.queryString wr
+        headers = Wai.requestHeaders wr
+        cookie = fromMaybe "" $ L.lookup "Cookie" headers
+        host = Host $ fromMaybe "" $ L.lookup "Host" headers
+        cookies = parseCookies cookie
+        method = Wai.requestMethod wr
+    pure $ Request{body, path, query, method, cookies, host}
+
+
+errNotHandled :: Event Text Text -> String
+errNotHandled ev =
+  L.intercalate
+    "\n"
+    [ "No Handler for Event viewId: " <> cs ev.viewId <> " action: " <> cs ev.action
+    , "<p>Remember to add a `hyper` handler in your page function</p>"
+    , "<pre>"
+    , "page :: (Hyperbole :> es) => Page es Response"
+    , "page = do"
+    , "  handle contentsHandler"
+    , "  load $ do"
+    , "    pure $ hyper Contents contentsView"
+    , "</pre>"
+    ]
+
+
+data ContentType
+  = ContentHtml
+  | ContentText
+
+
+contentType :: ContentType -> (HeaderName, BS.ByteString)
+contentType ContentHtml = ("Content-Type", "text/html; charset=utf-8")
+contentType ContentText = ("Content-Type", "text/plain; charset=utf-8")
+
+
+data SocketError
+  = InvalidMessage Text
+  deriving (Show, Eq)
+
+
+newtype Metadata = Metadata [(BL.ByteString, Text)]
+  deriving newtype (Semigroup, Monoid)
+
+
+runServerSockets
+  :: (IOE :> es)
+  => Connection
+  -> Request
+  -> Eff (Server : es) Response
+  -> Eff es Response
+runServerSockets conn req = reinterpret runLocal $ \_ -> \case
+  LoadRequest -> pure req -- receiveRequest conn
+  SendResponse sess res -> do
+    case res of
+      Response vid vw -> sendView (sessionMeta sess) vid vw
+      Err r -> sendError r
+      Empty -> sendError $ ErrOther "Empty"
+      NotFound -> sendError $ ErrOther "NotFound"
+      Redirect url -> sendRedirect (sessionMeta sess) url
+ where
+  runLocal = runErrorNoCallStackWith @SocketError onSocketError
+
+  onSocketError :: (IOE :> es) => SocketError -> Eff es Response
+  onSocketError e = do
+    let r = ErrOther $ cs $ show e
+    sendError r
+    pure $ Err r
+
+  sendMessage :: (MonadIO m) => Metadata -> BL.ByteString -> m ()
+  sendMessage meta cnt = do
+    let msg = renderMetadata meta <> "\n" <> cnt
+    liftIO $ WS.sendTextData conn msg
+
+  sendError :: (IOE :> es) => ResponseError -> Eff es ()
+  sendError r = do
+    -- TODO: better error handling!
+    sendMessage (metadata "ERROR" (pack (show r))) ""
+
+  sendView :: (IOE :> es) => Metadata -> TargetViewId -> View () () -> Eff es ()
+  sendView meta vid vw = do
+    sendMessage (viewIdMeta vid <> meta) (renderLazyByteString vw)
+
+  renderMetadata :: Metadata -> BL.ByteString
+  renderMetadata (Metadata m) = BL.intercalate "\n" $ fmap (uncurry metaLine) m
+
+  sendRedirect :: (IOE :> es) => Metadata -> Url -> Eff es ()
+  sendRedirect meta u = do
+    -- conn <- ask @Connection
+    let r = metadata "REDIRECT" (renderUrl u)
+    sendMessage (r <> meta) ""
+
+  sessionMeta :: Session -> Metadata
+  sessionMeta sess = Metadata [("SESSION", cs (sessionSetCookie sess))]
+
+  viewIdMeta :: TargetViewId -> Metadata
+  viewIdMeta (TargetViewId vid) = Metadata [("VIEW-ID", cs vid)]
+
+  metadata :: BL.ByteString -> Text -> Metadata
+  metadata name value = Metadata [(name, value)]
+
+  metaLine :: BL.ByteString -> Text -> BL.ByteString
+  metaLine name value = "|" <> name <> "|" <> cs value

--- a/src/Web/Hyperbole/Event.hs
+++ b/src/Web/Hyperbole/Event.hs
@@ -1,0 +1,12 @@
+module Web.Hyperbole.Event (Event (..)) where
+
+
+-- | An action, with its corresponding id
+data Event id act = Event
+  { viewId :: id
+  , action :: act
+  }
+
+
+instance (Show act, Show id) => Show (Event id act) where
+  show e = "Event " <> show e.viewId <> " " <> show e.action

--- a/src/Web/Hyperbole/Host.hs
+++ b/src/Web/Hyperbole/Host.hs
@@ -1,0 +1,7 @@
+module Web.Hyperbole.Host (Host (..)) where
+
+import Data.ByteString qualified as BS
+
+
+newtype Host = Host {text :: BS.ByteString}
+  deriving (Show)

--- a/src/Web/Hyperbole/Request.hs
+++ b/src/Web/Hyperbole/Request.hs
@@ -1,0 +1,18 @@
+module Web.Hyperbole.Request (Request (..)) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BL
+import Network.HTTP.Types hiding (Query)
+import Web.Hyperbole.Host (Host)
+import Web.View
+
+
+data Request = Request
+  { host :: Host
+  , path :: [Segment]
+  , query :: Query
+  , body :: BL.ByteString
+  , method :: Method
+  , cookies :: [(BS.ByteString, BS.ByteString)]
+  }
+  deriving (Show)

--- a/src/Web/Hyperbole/Response.hs
+++ b/src/Web/Hyperbole/Response.hs
@@ -1,0 +1,38 @@
+module Web.Hyperbole.Response
+  ( Response (..)
+  , ResponseError (..)
+  , TargetViewId (..)
+  )
+where
+
+import Data.Text (Text)
+import Web.Hyperbole.Event (Event)
+import Web.View
+
+
+-- | Serialized ViewId
+newtype TargetViewId = TargetViewId Text
+
+
+{- | Valid responses for a 'Hyperbole' effect. Use 'notFound', etc instead. Reminds you to use 'load' in your 'Page'
+
+> myPage :: (Hyperbole :> es) => Page es Response
+> myPage = do
+>   -- compiler error: () does not equal Response
+>   pure ()
+-}
+data Response
+  = Response TargetViewId (View () ())
+  | NotFound
+  | Redirect Url
+  | Err ResponseError
+  | Empty
+
+
+data ResponseError
+  = ErrParse Text
+  | ErrParam Text
+  | ErrOther Text
+  | ErrNotHandled (Event Text Text)
+  | ErrAuth
+  deriving (Show)


### PR DESCRIPTION
Hi @seanhess, while trying to get an overview of the code before taking a stab at implementing [server pushing](https://github.com/seanhess/hyperbole/issues/15#issuecomment-2239683567) I ended up moving code around a bit. I tried my best to not change any functionality at all but I'm not sure if this might've affected Haddock docs? Probably not. :thinking: 

Some notes:
- I created a dedicated module for the `Server` effect (in `Web.Hyperbole.Effect.Server`), so a lot of the code previously in `Web.Hyperbole.Application` ended up there.
- Dedicated modules for `Request`, `Response`, `Event`, `Host` types.
- Small readability changes (variable names, function ordering)

I understand that this is code churn and I mostly did it to get a deeper understanding of what's going on. I personally think this will allow the code to evolve better but I know you have ongoing efforts that might be impacted by merge conflicts after this, so feel free to ignore.