### PR TITLE
Use version 0.4.1 of `envparse` in nix environment

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,15 @@
                 }
                 { });
 
+            envparse =
+              super.callHackageDirect
+                {
+                  pkg = "envparse";
+                  ver = "0.4.1";
+                  sha256 = "sha256-Xf7z9UptgkY6C0etLonsCWRh3MrWjFlnnbrLGDfpDto=";
+                }
+                { };
+
           };
         };
       in


### PR DESCRIPTION
Hi @seanhess, I'm not sure why you pinned an older version of the `envparse` library but it broke the nix environment, since that version is no longer available in nixpkgs.

We are now building `envparse` from source but I think it won't be a great experience to other nix users who would like to try out hyperbole, since they too will have to add this workaround.

The fix works, but maybe you can shed some light on the problem with `sydtest` and we can try to figure out a better fix (or even open a PR upstream to fix it).