### PR TITLE
Better Handle/Load interface with tuples

### DIFF
--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -8,7 +8,7 @@ import Web.Hyperbole
 
 page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es '[Contents]
 page = do
-  handle content $ load $ do
+  handle content $ do
     pure $ do
       col (pad 20) $ do
         hyper (Contents 50) $ viewPoll 1

--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -6,7 +6,7 @@ import Example.Effects.Debug
 import Web.Hyperbole
 
 
-page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es '[Contents]
+page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es Contents
 page = do
   handle content $ do
     pure $ do

--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -18,7 +18,7 @@ page
    . (Hyperbole :> es, Users :> es, Debug :> es)
   => Page es '[Contacts, Contact]
 page = do
-  handle contacts $ handle contact $ load $ do
+  handle (contacts, contact) $ do
     us <- usersAll
     pure $ do
       col (pad 10 . gap 10) $ do

--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -16,7 +16,7 @@ import Web.Hyperbole
 page
   :: forall es
    . (Hyperbole :> es, Users :> es, Debug :> es)
-  => Page es '[Contacts, Contact]
+  => Page es (Contacts, Contact)
 page = do
   handle (contacts, contact) $ do
     us <- usersAll

--- a/example/Example/Counter.hs
+++ b/example/Example/Counter.hs
@@ -12,7 +12,7 @@ import Web.Hyperbole
 -- Optionally, the count could be stored in a session. See Example.Sessions
 page :: (Hyperbole :> es, Concurrent :> es) => TVar Int -> Page es '[Counter]
 page var = do
-  handle (counter var) $ load $ do
+  handle (counter var) $ do
     n <- readTVarIO var
     pure $ col (pad 20 . gap 10) $ do
       el h1 "Counter"

--- a/example/Example/Counter.hs
+++ b/example/Example/Counter.hs
@@ -10,7 +10,7 @@ import Web.Hyperbole
 -- We are using a TVar to manage our state
 -- In normal web applications, state will be managed in a database, abstracted behind a custom Effect. See Example.Effects.Users for the interface
 -- Optionally, the count could be stored in a session. See Example.Sessions
-page :: (Hyperbole :> es, Concurrent :> es) => TVar Int -> Page es '[Counter]
+page :: (Hyperbole :> es, Concurrent :> es) => TVar Int -> Page es Counter
 page var = do
   handle (counter var) $ do
     n <- readTVarIO var

--- a/example/Example/Errors.hs
+++ b/example/Example/Errors.hs
@@ -8,7 +8,7 @@ import Web.Hyperbole
 -- this is already running in a different context
 page :: (Hyperbole :> es) => Page es '[Contents]
 page = do
-  handle content $ load $ do
+  handle content $ do
     pure $ row (pad 20) $ do
       col (gap 10 . border 1) $ do
         hyper Contents viewContent

--- a/example/Example/Errors.hs
+++ b/example/Example/Errors.hs
@@ -6,7 +6,7 @@ import Web.Hyperbole
 
 
 -- this is already running in a different context
-page :: (Hyperbole :> es) => Page es '[Contents]
+page :: (Hyperbole :> es) => Page es Contents
 page = do
   handle content $ do
     pure $ row (pad 20) $ do

--- a/example/Example/Forms.hs
+++ b/example/Example/Forms.hs
@@ -11,7 +11,7 @@ import Web.Hyperbole
 
 page :: (Hyperbole :> es) => Page es '[FormView]
 page = do
-  handle formAction $ load $ do
+  handle formAction $ do
     pure $ row (pad 20) $ do
       hyper FormView (formView genForm)
 

--- a/example/Example/Forms.hs
+++ b/example/Example/Forms.hs
@@ -9,7 +9,7 @@ import Example.Style qualified as Style
 import Web.Hyperbole
 
 
-page :: (Hyperbole :> es) => Page es '[FormView]
+page :: (Hyperbole :> es) => Page es FormView
 page = do
   handle formAction $ do
     pure $ row (pad 20) $ do

--- a/example/Example/LazyLoading.hs
+++ b/example/Example/LazyLoading.hs
@@ -9,7 +9,7 @@ import Web.Hyperbole
 -- this is already running in a different context
 page :: (Hyperbole :> es, Debug :> es) => Page es '[Contents]
 page = do
-  handle content $ load $ do
+  handle content $ do
     pure $ do
       row (pad 20) $ do
         col (gap 10 . border 1 . pad 20) $ do

--- a/example/Example/LazyLoading.hs
+++ b/example/Example/LazyLoading.hs
@@ -7,7 +7,7 @@ import Web.Hyperbole
 
 
 -- this is already running in a different context
-page :: (Hyperbole :> es, Debug :> es) => Page es '[Contents]
+page :: (Hyperbole :> es, Debug :> es) => Page es Contents
 page = do
   handle content $ do
     pure $ do

--- a/example/Example/Redirects.hs
+++ b/example/Example/Redirects.hs
@@ -5,7 +5,7 @@ import Example.Style as Style
 import Web.Hyperbole
 
 
-page :: (Hyperbole :> es) => Page es '[Contents]
+page :: (Hyperbole :> es) => Page es Contents
 page = do
   handle contents $ do
     pure $ row (pad 20) $ do

--- a/example/Example/Redirects.hs
+++ b/example/Example/Redirects.hs
@@ -7,7 +7,7 @@ import Web.Hyperbole
 
 page :: (Hyperbole :> es) => Page es '[Contents]
 page = do
-  handle contents $ load $ do
+  handle contents $ do
     pure $ row (pad 20) $ do
       hyper Contents contentsView
 

--- a/example/Example/Search.hs
+++ b/example/Example/Search.hs
@@ -7,7 +7,7 @@ import Web.Hyperbole
 import Prelude hiding (even, odd)
 
 
-page :: (Hyperbole :> es) => Page es '[LiveSearch]
+page :: (Hyperbole :> es) => Page es LiveSearch
 page = do
   handle liveSearch $ do
     pure $ col (pad 20) $ do

--- a/example/Example/Search.hs
+++ b/example/Example/Search.hs
@@ -9,7 +9,7 @@ import Prelude hiding (even, odd)
 
 page :: (Hyperbole :> es) => Page es '[LiveSearch]
 page = do
-  handle liveSearch $ load $ do
+  handle liveSearch $ do
     pure $ col (pad 20) $ do
       el bold "Filter Programming Languages"
       hyper LiveSearch $ liveSearchView allLanguages Nothing

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -10,7 +10,7 @@ import Web.Hyperbole
 
 
 -- this is already running in a different context
-page :: (Hyperbole :> es, Debug :> es) => Page es '[Contents]
+page :: (Hyperbole :> es, Debug :> es) => Page es Contents
 page = do
   handle content $ do
     -- setSession "color" Warning

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -12,7 +12,7 @@ import Web.Hyperbole
 -- this is already running in a different context
 page :: (Hyperbole :> es, Debug :> es) => Page es '[Contents]
 page = do
-  handle content $ load $ do
+  handle content $ do
     -- setSession "color" Warning
     -- setSession "msg" ("________" :: Text)
     (clr :: Maybe AppColor) <- session "color"

--- a/example/Example/Simple.hs
+++ b/example/Example/Simple.hs
@@ -16,7 +16,7 @@ main = do
 
 simplePage :: (Hyperbole :> es) => Page es '[Message]
 simplePage = do
-  handle message $ load $ do
+  handle message $ do
     pure $ col (pad 20) $ do
       el bold "My Page"
       hyper (Message 1) $ messageView "Hello"

--- a/example/Example/Simple.hs
+++ b/example/Example/Simple.hs
@@ -14,7 +14,7 @@ main = do
     liveApp (basicDocument "Example") (page simplePage)
 
 
-simplePage :: (Hyperbole :> es) => Page es '[Message]
+simplePage :: (Hyperbole :> es) => Page es Message
 simplePage = do
   handle message $ do
     pure $ col (pad 20) $ do

--- a/example/Example/Transitions.hs
+++ b/example/Example/Transitions.hs
@@ -5,7 +5,7 @@ import Example.Style as Style
 import Web.Hyperbole
 
 
-page :: (Hyperbole :> es) => Page es '[Contents]
+page :: (Hyperbole :> es) => Page es Contents
 page = do
   handle content $ do
     pure $ row (pad 20) $ do

--- a/example/Example/Transitions.hs
+++ b/example/Example/Transitions.hs
@@ -7,7 +7,7 @@ import Web.Hyperbole
 
 page :: (Hyperbole :> es) => Page es '[Contents]
 page = do
-  handle content $ load $ do
+  handle content $ do
     pure $ row (pad 20) $ do
       hyper Contents viewSmall
 

--- a/example/HelloWorld.hs
+++ b/example/HelloWorld.hs
@@ -10,7 +10,7 @@ main = do
     liveApp (basicDocument "Example") (page messagePage')
 
 
-messagePage :: (Hyperbole :> es) => Page es '[]
+messagePage :: (Hyperbole :> es) => Page es ()
 messagePage = do
   handle () $ do
     pure $ do
@@ -49,7 +49,7 @@ messageView' m = do
   button (SetMessage "Goodbye World") id "Change Message"
 
 
-messagePage' :: (Hyperbole :> es) => Page es '[Message]
+messagePage' :: (Hyperbole :> es) => Page es Message
 messagePage' = do
   handle message $ do
     pure $ do

--- a/example/HelloWorld.hs
+++ b/example/HelloWorld.hs
@@ -12,7 +12,7 @@ main = do
 
 messagePage :: (Hyperbole :> es) => Page es '[]
 messagePage = do
-  load $ do
+  handle () $ do
     pure $ do
       el bold "Message Page"
       messageView "Hello World"
@@ -51,7 +51,7 @@ messageView' m = do
 
 messagePage' :: (Hyperbole :> es) => Page es '[Message]
 messagePage' = do
-  handle message $ load $ do
+  handle message $ do
     pure $ do
       el bold "Message Page"
       hyper Message $ messageView' "Hello World"

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -38,7 +38,7 @@ import Network.Wai.Handler.Warp qualified as Warp
 import Network.Wai.Middleware.Static (addBase, staticPolicy)
 import Network.WebSockets (Connection, PendingConnection, acceptRequest, defaultConnectionOptions)
 import Web.Hyperbole
-import Web.Hyperbole.Effect (Request (..))
+import Web.Hyperbole.Effect.Server (Request (..))
 
 
 -- import Network.Wai.Handler.WebSockets (websocketsOr)
@@ -131,9 +131,9 @@ app users count = do
 
   -- Nested Router
   hello :: (Hyperbole :> es, Debug :> es) => Hello -> Page es '[]
-  hello Redirected = load $ do
+  hello Redirected = handle () $ do
     pure $ el_ "You were redirected"
-  hello (Greet s) = load $ do
+  hello (Greet s) = handle () $ do
     r <- request
     pure $ col (gap 10 . pad 10) $ do
       el_ $ do

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -130,7 +130,7 @@ app users count = do
   lnk = Style.link
 
   -- Nested Router
-  hello :: (Hyperbole :> es, Debug :> es) => Hello -> Page es '[]
+  hello :: (Hyperbole :> es, Debug :> es) => Hello -> Page es ()
   hello Redirected = handle () $ do
     pure $ el_ "You were redirected"
   hello (Greet s) = handle () $ do

--- a/example/hyperbole-examples.cabal
+++ b/example/hyperbole-examples.cabal
@@ -27,14 +27,19 @@ executable examples
       Simple
       Web.Hyperbole
       Web.Hyperbole.Application
-      Web.Hyperbole.Effect
+      Web.Hyperbole.Effect.Hyperbole
+      Web.Hyperbole.Effect.Server
       Web.Hyperbole.Embed
       Web.Hyperbole.Forms
+      Web.Hyperbole.Handler
+      Web.Hyperbole.Handler.TypeList
       Web.Hyperbole.HyperView
       Web.Hyperbole.Route
       Web.Hyperbole.Session
-      Web.Hyperbole.Types
       Web.Hyperbole.View
+      Web.Hyperbole.View.Element
+      Web.Hyperbole.View.Event
+      Web.Hyperbole.View.Target
       BulkUpdate
       Example.Colors
       Example.Concurrent

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -16,7 +16,7 @@ main = do
     liveApp (basicDocument "Example") (page simplePage)
 
 
-simplePage :: (Hyperbole :> es, IOE :> es) => Page es '[MainView, Status]
+simplePage :: (Hyperbole :> es, IOE :> es) => Page es [MainView, Status]
 simplePage = do
   handle (main', status) $ do
     liftIO $ putStrLn "MAIN LOAD"
@@ -25,25 +25,6 @@ simplePage = do
       hyper MainView $ do
         row (gap 10) $ do
           button GoBegin (border 1) "Start"
-
-
-simplePage1 :: (Hyperbole :> es, IOE :> es) => Page es '[Floop]
-simplePage1 = do
-  handle floop $ do
-    liftIO $ putStrLn "MAIN LOAD"
-    pure $ col (pad 20) $ do
-      el bold "My Page"
-      hyper Floop $ do
-        row (gap 10) $ do
-          button FloopA (border 1) "Start"
-
-
-simplePage0 :: (Hyperbole :> es, IOE :> es) => Page es '[]
-simplePage0 = do
-  handle () $ do
-    liftIO $ putStrLn "MAIN LOAD"
-    pure $ col (pad 20) $ do
-      el bold "My Page"
 
 
 data Floop = Floop

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -18,13 +18,48 @@ main = do
 
 simplePage :: (Hyperbole :> es, IOE :> es) => Page es '[MainView, Status]
 simplePage = do
-  handle main' $ handle status $ load $ do
+  handle (main', status) $ do
     liftIO $ putStrLn "MAIN LOAD"
     pure $ col (pad 20) $ do
       el bold "My Page"
       hyper MainView $ do
         row (gap 10) $ do
           button GoBegin (border 1) "Start"
+
+
+simplePage1 :: (Hyperbole :> es, IOE :> es) => Page es '[Floop]
+simplePage1 = do
+  handle floop $ do
+    liftIO $ putStrLn "MAIN LOAD"
+    pure $ col (pad 20) $ do
+      el bold "My Page"
+      hyper Floop $ do
+        row (gap 10) $ do
+          button FloopA (border 1) "Start"
+
+
+simplePage0 :: (Hyperbole :> es, IOE :> es) => Page es '[]
+simplePage0 = do
+  handle () $ do
+    liftIO $ putStrLn "MAIN LOAD"
+    pure $ col (pad 20) $ do
+      el bold "My Page"
+
+
+data Floop = Floop
+  deriving (Show, Read, ViewId)
+
+
+data FloopA = FloopA
+  deriving (Show, Read, ViewAction)
+
+
+instance HyperView Floop where
+  type Action Floop = FloopA
+
+
+floop :: Floop -> FloopA -> Eff es (View Floop ())
+floop _ _ = pure none
 
 
 -- MAIN ----------------------------------------

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -16,7 +16,7 @@ main = do
     liveApp (basicDocument "Example") (page simplePage)
 
 
-simplePage :: (Hyperbole :> es, IOE :> es) => Page es [MainView, Status]
+simplePage :: (Hyperbole :> es, IOE :> es) => Page es (MainView, Status)
 simplePage = do
   handle (main', status) $ do
     liftIO $ putStrLn "MAIN LOAD"
@@ -25,6 +25,25 @@ simplePage = do
       hyper MainView $ do
         row (gap 10) $ do
           button GoBegin (border 1) "Start"
+
+
+simplePage1 :: (Hyperbole :> es, IOE :> es) => Page es Floop
+simplePage1 = do
+  handle floop $ do
+    liftIO $ putStrLn "MAIN LOAD"
+    pure $ col (pad 20) $ do
+      el bold "My Page"
+      hyper Floop $ do
+        row (gap 10) $ do
+          button FloopA (border 1) "Start"
+
+
+simplePage0 :: (Hyperbole :> es, IOE :> es) => Page es ()
+simplePage0 = do
+  handle () $ do
+    liftIO $ putStrLn "MAIN LOAD"
+    pure $ col (pad 20) $ do
+      el bold "My Page"
 
 
 data Floop = Floop

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -123,8 +123,8 @@ module Web.Hyperbole
   , ViewAction
   , Response
   , handle
-  , load
-  , Handler
+  -- , load
+  -- , Handler
   , Root
   , HyperViewHandled
 

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -99,12 +99,12 @@ instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, Hyper
 
 handle
   :: forall views es
-   . (Handle views, Hyperbole :> es)
-  => Handlers es views
-  -> Eff es (View (Root views) ())
+   . (Handle (TupleList views), Hyperbole :> es)
+  => Handlers es (TupleList views)
+  -> Eff es (View (Root (TupleList views)) ())
   -> Page es views
 handle handlers loadPage = Page $ do
-  runHandlers @views handlers
+  runHandlers @(TupleList views) handlers
   guardNoEvent
   loadPage
 
@@ -195,7 +195,7 @@ pageView = do
   'hyper' (Message 1) $ messageView "Starting Message"
 @
 -}
-newtype Page (es :: [Effect]) (views :: [Type]) = Page (Eff es (View (Root views) ()))
+newtype Page (es :: [Effect]) (views :: Type) = Page (Eff es (View (Root (TupleList views)) ()))
 
 
 -- | Run a 'Page' in 'Hyperbole'

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -1,16 +1,14 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Web.Hyperbole.Handler
   ( Page (..)
   , page
   , handle
   , Hyperbole (..)
-  -- , Handler
   )
 where
 
-import Data.Kind (Constraint, Type)
+import Data.Kind (Type)
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Web.Hyperbole.Effect.Hyperbole
@@ -62,6 +60,41 @@ instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e) => Ha
   runHandlers (a, b, c, d, e) = do
     runHandlers @'[a, b, c, d] (a, b, c, d)
     runHandler e
+
+
+instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, HyperView f) => Handle '[a, b, c, d, e, f] where
+  type Handlers es '[a, b, c, d, e, f] = (Handlers es '[a], Handlers es '[b], Handlers es '[c], Handlers es '[d], Handlers es '[e], Handlers es '[f])
+  runHandlers (a, b, c, d, e, f) = do
+    runHandlers @'[a, b, c, d, e] (a, b, c, d, e)
+    runHandler f
+
+
+instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, HyperView f, HyperView g) => Handle '[a, b, c, d, e, f, g] where
+  type Handlers es '[a, b, c, d, e, f, g] = (Handlers es '[a], Handlers es '[b], Handlers es '[c], Handlers es '[d], Handlers es '[e], Handlers es '[f], Handlers es '[g])
+  runHandlers (a, b, c, d, e, f, g) = do
+    runHandlers @'[a, b, c, d, e, f] (a, b, c, d, e, f)
+    runHandler g
+
+
+instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, HyperView f, HyperView g, HyperView h) => Handle '[a, b, c, d, e, f, g, h] where
+  type Handlers es '[a, b, c, d, e, f, g, h] = (Handlers es '[a], Handlers es '[b], Handlers es '[c], Handlers es '[d], Handlers es '[e], Handlers es '[f], Handlers es '[g], Handlers es '[h])
+  runHandlers (a, b, c, d, e, f, g, h) = do
+    runHandlers @'[a, b, c, d, e, f, g] (a, b, c, d, e, f, g)
+    runHandler h
+
+
+instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, HyperView f, HyperView g, HyperView h, HyperView i) => Handle '[a, b, c, d, e, f, g, h, i] where
+  type Handlers es '[a, b, c, d, e, f, g, h, i] = (Handlers es '[a], Handlers es '[b], Handlers es '[c], Handlers es '[d], Handlers es '[e], Handlers es '[f], Handlers es '[g], Handlers es '[h], Handlers es '[i])
+  runHandlers (a, b, c, d, e, f, g, h, i) = do
+    runHandlers @'[a, b, c, d, e, f, g, h] (a, b, c, d, e, f, g, h)
+    runHandler i
+
+
+instance (HyperView a, HyperView b, HyperView c, HyperView d, HyperView e, HyperView f, HyperView g, HyperView h, HyperView i, HyperView j) => Handle '[a, b, c, d, e, f, g, h, i, j] where
+  type Handlers es '[a, b, c, d, e, f, g, h, i, j] = (Handlers es '[a], Handlers es '[b], Handlers es '[c], Handlers es '[d], Handlers es '[e], Handlers es '[f], Handlers es '[g], Handlers es '[h], Handlers es '[i], Handlers es '[j])
+  runHandlers (a, b, c, d, e, f, g, h, i, j) = do
+    runHandlers @'[a, b, c, d, e, f, g, h, i] (a, b, c, d, e, f, g, h, i)
+    runHandler j
 
 
 handle

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -66,3 +66,10 @@ data Root (views :: [Type]) = Root
 instance HyperView (Root views) where
   type Action (Root views) = ()
   type Require (Root views) = views
+
+
+type family TupleList a where
+  TupleList () = '[]
+  TupleList (a, b) = [a, b]
+  TupleList (a, b, c) = [a, b, c]
+  TupleList a = '[a]


### PR DESCRIPTION
In #31 @benjaminweb correctly pointed out that the new type-safe handler API is annoying. We can't use the monadic interface any more, and the current main branch has an interface like:

```
page :: Hyperbole :> es => Page es '[Central, Presets, Handler3]
page = 
  handle central $ handle presets $ handle handler3 $ load $ do
    ...
```

With this PR, it changes to this:

```
page :: Hyperbole :> es => Page es (Central, Presets, Handler3)
page = 
  handle (central, presets, handler3) $ do
    ...
```

It doesn't require calling `load`, it's intuitive, and much more terse. I like it a lot. 

Any feedback?