### PR TITLE
Component API

### DIFF
--- a/example/hyperbole-examples.cabal
+++ b/example/hyperbole-examples.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -23,9 +23,11 @@ source-repository head
 executable examples
   main-is: Main.hs
   other-modules:
+      Nested
       Simple
       Web.Hyperbole
       Web.Hyperbole.Application
+      Web.Hyperbole.Component
       Web.Hyperbole.Effect.Hyperbole
       Web.Hyperbole.Effect.Server
       Web.Hyperbole.Embed

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.36.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,9 +31,11 @@ source-repository head
 
 library
   exposed-modules:
+      Nested
       Simple
       Web.Hyperbole
       Web.Hyperbole.Application
+      Web.Hyperbole.Component
       Web.Hyperbole.Effect.Hyperbole
       Web.Hyperbole.Effect.Server
       Web.Hyperbole.Embed

--- a/src/Nested.hs
+++ b/src/Nested.hs
@@ -22,7 +22,7 @@ page = do
 
 
 data MainView = MainView
-  deriving (Show, Read, ViewId, HyperView)
+  deriving (Show, Read, ViewId)
 
 
 instance Component MainView where
@@ -66,7 +66,7 @@ mainControls = col (gap 5) $ do
 
 
 data Listener = Listener Int
-  deriving (Show, Read, ViewId, HyperView)
+  deriving (Show, Read, ViewId)
 
 
 instance Handle Listener es where

--- a/src/Nested.hs
+++ b/src/Nested.hs
@@ -25,7 +25,7 @@ data MainView = MainView
 
 
 instance Component MainView es where
-  data Msg MainView
+  data Action MainView
     = Broadcast Text
     | ClearAll
     deriving (Show, Read)
@@ -36,7 +36,7 @@ instance Component MainView es where
     }
 
 
-  type Import MainView = '[Listener]
+  type Require MainView = '[Listener]
 
 
   render model = do
@@ -68,7 +68,7 @@ instance Component Listener es where
     }
 
 
-  data Msg Listener
+  data Action Listener
     = Display Text
     | Shout Text
     deriving (Show, Read)

--- a/src/Nested.hs
+++ b/src/Nested.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Nested where
+
+import Control.Monad (forM_)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Effectful
+import Effectful.Concurrent.STM
+import Web.Hyperbole
+import Web.Hyperbole.Component
+import Web.Hyperbole.Effect.Hyperbole (start)
+
+
+page :: (Hyperbole :> es, Concurrent :> es) => Page es '[MainView, Listener]
+page = do
+  pure $ col (pad 20 . gap 10) $ do
+    el bold "Triggers Nested"
+    start MainView MainViewModel{broadcast = Nothing}
+
+
+data MainView = MainView
+  deriving (Show, Read, ViewId, HyperView)
+
+
+instance Component MainView where
+  data Msg MainView
+    = Broadcast Text
+    | ClearAll
+    deriving (Show, Read)
+
+
+  data Model MainView = MainViewModel
+    { broadcast :: Maybe Text
+    }
+
+
+  type Import MainView = '[Listener]
+
+
+  render model = do
+    let msg = fromMaybe "ready" model.broadcast
+    row (gap 10) $ do
+      mainControls
+      forM_ [0 .. 4] $ \i -> do
+        start (Listener i) ListenerModel{msg}
+
+
+  update (Broadcast t) = do
+    pure $ render $ MainViewModel{broadcast = Just t}
+  update ClearAll = do
+    pure $ render $ MainViewModel{broadcast = Just ""}
+
+
+instance Handle MainView es where
+  handle = update
+
+
+mainControls :: View MainView ()
+mainControls = col (gap 5) $ do
+  button ClearAll Prelude.id "Clear"
+  button (Broadcast "hello") Prelude.id "Broadcast hello"
+  button (Broadcast "goodbye") Prelude.id "Broadcast goodbye"
+
+
+data Listener = Listener Int
+  deriving (Show, Read, ViewId, HyperView)
+
+
+instance Handle Listener es where
+  handle = update
+
+
+instance Component Listener where
+  data Model Listener = ListenerModel
+    { msg :: Text
+    }
+
+
+  data Msg Listener
+    = Display Text
+    | Shout Text
+    deriving (Show, Read)
+
+
+  render :: Model Listener -> View Listener ()
+  render model = do
+    el (border 1 . textAlign Center) (text model.msg)
+    row (gap 10) $ do
+      button (Display "Hi") Prelude.id "Say Hi"
+      button (Display "Bye") Prelude.id "Say Bye"
+
+
+  update = \case
+    (Display msg) -> do
+      pure $ render $ ListenerModel{msg}
+    Shout msg -> do
+      pure $ render $ ListenerModel{msg = Text.toUpper msg}

--- a/src/Nested.hs
+++ b/src/Nested.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Page.Triggers.Nested where
+module Nested where
 
 import Control.Monad (forM_)
 import Data.Maybe (fromMaybe)
@@ -9,7 +9,7 @@ import Data.Text qualified as Text
 import Effectful
 import Effectful.Concurrent.STM
 import Web.Hyperbole
-import Web.Hyperbole.Component (Component (..))
+import Web.Hyperbole.Component (Component (..), IsAction, ViewId)
 import Web.Hyperbole.Effect.Hyperbole (start)
 
 
@@ -28,7 +28,7 @@ instance Component MainView es where
   data Action MainView
     = Broadcast Text
     | ClearAll
-    deriving (Show, Read)
+    deriving (Show, Read, IsAction)
 
 
   data Model MainView = MainViewModel
@@ -40,13 +40,13 @@ instance Component MainView es where
 
 
   render model = do
-    let msg = fromMaybe "ready" model.broadcast
     row (gap 10) $ do
       col (gap 5) $ do
         button ClearAll Prelude.id "Clear"
         button (Broadcast "hello") Prelude.id "Broadcast hello"
         button (Broadcast "goodbye") Prelude.id "Broadcast goodbye"
 
+      let msg = fromMaybe "ready" model.broadcast
       forM_ [0 .. 4] $ \i -> do
         start (Listener i) ListenerModel{msg}
 
@@ -71,11 +71,7 @@ instance Component Listener es where
   data Action Listener
     = Display Text
     | Shout Text
-    deriving (Show, Read)
-
-
-  -- Add additional effects required by the component
-  type Effects Listener es = ()
+    deriving (Show, Read, IsAction)
 
 
   render :: Model Listener -> View Listener ()

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -12,7 +12,7 @@ import Effectful
 import Effectful.Concurrent.STM
 import Effectful.Reader.Dynamic
 import Web.Hyperbole
-import Web.Hyperbole.Component (Component (..))
+import Web.Hyperbole.Component (Component (..), IsAction, ViewId)
 import Web.Hyperbole.Effect.Hyperbole (start)
 
 
@@ -48,7 +48,7 @@ instance Component Counter es where
   data Action Counter
     = Increment
     | Decrement
-    deriving (Show, Read)
+    deriving (Show, Read, IsAction)
 
 
   -- Add additional effects required by the component. Can be omitted if there are none.
@@ -67,6 +67,8 @@ instance Component Counter es where
   -- Ideally the update function would only run effects and update the model without having to render the view manually. Its signature could change to receive the previous model and the action instead of just the action.
   update = \case
     Increment -> do
+      -- Inside the update function we have access to the effects defined in the
+      -- associated type 'Effects c es':
       n <- modify $ \n -> n + 1
       pure $ render $ CounterModel{count = n}
     Decrement -> do

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -45,7 +45,7 @@ instance Component Counter es where
     }
 
 
-  data Msg Counter
+  data Action Counter
     = Increment
     | Decrement
     deriving (Show, Read)

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -74,10 +74,6 @@ instance Component Counter es where
       pure $ render $ CounterModel{count = n}
 
 
--- -- | This instance becomes trivial, and ideally the Handle class can be eliminated
--- instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
---   handle = update
-
 viewCount :: Int -> View Counter ()
 viewCount n = col (gap 10) $ do
   row id $ do

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -36,7 +36,7 @@ page = do
 
 
 data Counter = Counter
-  deriving (Show, Read, ViewId, HyperView)
+  deriving (Show, Read, ViewId)
 
 
 instance Component Counter where

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -39,7 +39,7 @@ data Counter = Counter
   deriving (Show, Read, ViewId)
 
 
-instance Component Counter where
+instance Component Counter es where
   data Model Counter = CounterModel
     { count :: Int
     }
@@ -74,10 +74,9 @@ instance Component Counter where
       pure $ render $ CounterModel{count = n}
 
 
--- | This instance becomes trivial, and ideally the Handle class can be eliminated
-instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
-  handle = update
-
+-- -- | This instance becomes trivial, and ideally the Handle class can be eliminated
+-- instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
+--   handle = update
 
 viewCount :: Int -> View Counter ()
 viewCount n = col (gap 10) $ do

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -120,7 +120,6 @@ module Web.Hyperbole
   , target
   , view
   , ViewId
-  , ViewAction
   , Response
   , Root
   , HyperViewHandled

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -81,7 +81,6 @@ module Web.Hyperbole
   , InputType (..)
 
     -- ** Handlers
-  , Handle (..)
   , viewId
   , Page
 

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -117,7 +117,6 @@ module Web.Hyperbole
     -- * Advanced
   , target
   , view
-  , ViewId
   , Response
   , Root
   , HyperViewHandled

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -41,7 +41,6 @@ module Web.Hyperbole
     -- ** Page
 
     -- ** HyperView
-  , HyperView (..)
   , hyper
 
     -- * Interactive Elements

--- a/src/Web/Hyperbole/Component.hs
+++ b/src/Web/Hyperbole/Component.hs
@@ -1,41 +1,70 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
 
 module Web.Hyperbole.Component where
 
 import Data.Kind (Constraint, Type)
+import Data.Text (Text, pack, unpack)
 import Effectful
 import Effectful.Reader.Dynamic (Reader)
+import Text.Read (readMaybe)
 import Web.View
 
 
 -- | A 'Component' is a self-contained piece of a 'Page'.
-class Component c es where
-  -- | The data used by the component
+class (ViewId c, IsAction (Action c)) => Component c es where
+  -- | The data used by the component.
   data Model c
 
 
-  -- | The possible messages supported by the component
+  -- | The actions supported by the component.
   data Action c
 
 
-  -- | Additional effects required by the component. Can be omitted if none are needed.
+  -- | Additional effects required by the component. Can be omitted.
   type Effects c (es :: [Effect]) :: Constraint
 
 
   type Effects c es = ()
 
 
-  -- | Other components nested in the component.
-  -- Can be omitted if none are needed.
+  -- | Other components nested in the component. Can be omitted.
   type Require c :: [Type]
 
 
   type Require c = '[]
 
 
-  -- | Render the component
+  -- | Render the component.
   render :: Model c -> View c ()
 
 
   -- | Update the component based on a message. Ideally would only change the data model and leave rendering to the 'render' function.
   update :: (Effects c es) => Action c -> Eff (Reader c : es) (View c ())
+
+
+class ViewId a where
+  toViewId :: a -> Text
+  default toViewId :: (Show a) => a -> Text
+  toViewId = pack . show
+
+
+  parseViewId :: Text -> Maybe a
+  default parseViewId :: (Read a) => Text -> Maybe a
+  parseViewId = readMaybe . unpack
+
+
+class (Show a, Read a) => IsAction a where
+  toAction :: a -> Text
+  default toAction :: (Show a) => a -> Text
+  toAction = pack . show
+
+
+  parseAction :: Text -> Maybe a
+  default parseAction :: (Read a) => Text -> Maybe a
+  parseAction = readMaybe . unpack
+
+
+instance IsAction () where
+  toAction _ = ""
+  parseAction _ = Just ()

--- a/src/Web/Hyperbole/Component.hs
+++ b/src/Web/Hyperbole/Component.hs
@@ -10,7 +10,11 @@ import Web.View
 
 -- | A 'Component' is a self-contained piece of a 'Page'.
 class Component c es where
+  -- | The data used by the component
   data Model c
+
+
+  -- | The possible messages supported by the component
   data Msg c
 
 
@@ -21,12 +25,17 @@ class Component c es where
   type Effects c es = ()
 
 
-  -- | Other components required by this component
+  -- | Other components nested in the component.
+  -- Can be omitted if none are needed.
   type Import c :: [Type]
 
 
   type Import c = '[]
 
 
+  -- | Render the component
   render :: Model c -> View c ()
+
+
+  -- | Update the component based on a message. Ideally would only change the data model and leave rendering to the 'render' function.
   update :: (Effects c es) => Msg c -> Eff (Reader c : es) (View c ())

--- a/src/Web/Hyperbole/Component.hs
+++ b/src/Web/Hyperbole/Component.hs
@@ -15,7 +15,7 @@ class Component c es where
 
 
   -- | The possible messages supported by the component
-  data Msg c
+  data Action c
 
 
   -- | Additional effects required by the component. Can be omitted if none are needed.
@@ -27,10 +27,10 @@ class Component c es where
 
   -- | Other components nested in the component.
   -- Can be omitted if none are needed.
-  type Import c :: [Type]
+  type Require c :: [Type]
 
 
-  type Import c = '[]
+  type Require c = '[]
 
 
   -- | Render the component
@@ -38,4 +38,4 @@ class Component c es where
 
 
   -- | Update the component based on a message. Ideally would only change the data model and leave rendering to the 'render' function.
-  update :: (Effects c es) => Msg c -> Eff (Reader c : es) (View c ())
+  update :: (Effects c es) => Action c -> Eff (Reader c : es) (View c ())

--- a/src/Web/Hyperbole/Component.hs
+++ b/src/Web/Hyperbole/Component.hs
@@ -1,0 +1,30 @@
+module Web.Hyperbole.Component where
+
+import Data.Kind (Constraint, Type)
+import Effectful
+import Effectful.Reader.Dynamic (Reader)
+import Web.View
+
+
+-- | A 'Component' is a self-contained piece of a 'Page'.
+class Component c where
+  data Model c
+  data Msg c
+
+
+  -- | Additional effects required by the component. Can be omitted if none are needed.
+  type Effects c (es :: [Effect]) :: Constraint
+
+
+  type Effects c es = ()
+
+
+  -- | Other components required by this component
+  type Import c :: [Type]
+
+
+  type Import c = '[]
+
+
+  render :: Model c -> View c ()
+  update :: (Effects c es) => Msg c -> Eff (Reader c : es) (View c ())

--- a/src/Web/Hyperbole/Component.hs
+++ b/src/Web/Hyperbole/Component.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Web.Hyperbole.Component where
 
 import Data.Kind (Constraint, Type)
@@ -7,7 +9,7 @@ import Web.View
 
 
 -- | A 'Component' is a self-contained piece of a 'Page'.
-class Component c where
+class Component c es where
   data Model c
   data Msg c
 

--- a/src/Web/Hyperbole/Effect/Hyperbole.hs
+++ b/src/Web/Hyperbole/Effect/Hyperbole.hs
@@ -27,13 +27,13 @@ import Web.View
 
 
 hyper
-  :: forall id ctx
-   . ( HyperViewHandled id ctx
-     , ViewId id
-     , Component id
+  :: forall c ctx
+   . ( HyperViewHandled c ctx
+     , ViewId c
+     , Component c
      )
-  => id
-  -> View id ()
+  => c
+  -> View c ()
   -> View ctx ()
 hyper = hyperUnsafe
 
@@ -135,13 +135,13 @@ formBody = do
   either (send . RespondEarly . Err . ErrParse) pure ef
 
 
-getEvent :: (Read (Msg id), HyperView id, Hyperbole :> es) => Eff es (Maybe (Event id (Msg id)))
+getEvent :: (Read (Msg id), Component id, Hyperbole :> es, ViewId id) => Eff es (Maybe (Event id (Msg id)))
 getEvent = do
   q <- reqParams
   pure $ parseEvent q
 
 
-parseEvent :: (Read (Msg id), HyperView id) => Query -> Maybe (Event id (Msg id))
+parseEvent :: (Read (Msg id), Component id, ViewId id) => Query -> Maybe (Event id (Msg id))
 parseEvent q = do
   Event ti ta <- lookupEvent q
   vid <- parseViewId ti
@@ -270,7 +270,7 @@ redirect = send . RespondEarly . Redirect
 
 
 -- | Respond with the given view, and stop execution
-respondEarly :: (Component id, Hyperbole :> es, HyperView id) => id -> View id () -> Eff es ()
+respondEarly :: (Component id, Hyperbole :> es, ViewId id) => id -> View id () -> Eff es ()
 respondEarly i vw = do
   let vid = TargetViewId (toViewId i)
   let res = Response vid $ hyperUnsafe i vw

--- a/src/Web/Hyperbole/Effect/Hyperbole.hs
+++ b/src/Web/Hyperbole/Effect/Hyperbole.hs
@@ -39,6 +39,7 @@ hyper
 hyper = hyperUnsafe @c @es
 
 
+-- | Initialize a given component giving it an initial value.
 start
   :: forall c ctx es
    . ( HyperViewHandled c ctx es
@@ -137,13 +138,13 @@ formBody = do
   either (send . RespondEarly . Err . ErrParse) pure ef
 
 
-getEvent :: forall id es. (Read (Msg id), Component id es, Hyperbole :> es, ViewId id) => Eff es (Maybe (Event id (Msg id)))
+getEvent :: forall id es. (Read (Action id), Component id es, Hyperbole :> es, ViewId id) => Eff es (Maybe (Event id (Action id)))
 getEvent = do
   q <- reqParams
   pure $ parseEvent @id @es q
 
 
-parseEvent :: (Read (Msg id), Component id es, ViewId id) => Query -> Maybe (Event id (Msg id))
+parseEvent :: (Read (Action id), Component id es, ViewId id) => Query -> Maybe (Event id (Action id))
 parseEvent q = do
   Event ti ta <- lookupEvent q
   vid <- parseViewId ti

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -46,6 +46,7 @@ import Text.Casing (kebab)
 import Web.FormUrlEncoded (FormOptions (..), defaultFormOptions, parseUnique)
 import Web.FormUrlEncoded qualified as FE
 import Web.HttpApiData (FromHttpApiData (..))
+import Web.Hyperbole.Component (IsAction (..), ViewId)
 import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.View.Target (dataTarget)
@@ -294,14 +295,14 @@ userForm v = do
     'submit' (border 1) \"Submit\"
 @
 -}
-form :: (Show (Action id), Form form val, ViewId id) => Action id -> Mod -> View (FormFields id) () -> View id ()
+form :: (IsAction (Action id), Form form val, ViewId id) => Action id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
 
   tag "form" (onSubmit a . dataTarget vid . md . flexCol) $ do
     addContext (FormFields vid) cnt
  where
-  onSubmit :: (Show (Action a)) => Action a -> Mod
+  onSubmit :: (IsAction (Action a)) => Action a -> Mod
   onSubmit = att "data-on-submit" . toAction
 
 

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -294,14 +294,14 @@ userForm v = do
     'submit' (border 1) \"Submit\"
 @
 -}
-form :: (Form form val, HyperView id) => Action id -> Mod -> View (FormFields id) () -> View id ()
+form :: (Show (Msg id), Form form val, HyperView id) => Msg id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
 
   tag "form" (onSubmit a . dataTarget vid . md . flexCol) $ do
     addContext (FormFields vid) cnt
  where
-  onSubmit :: (ViewAction a) => a -> Mod
+  onSubmit :: (Show (Msg a)) => Msg a -> Mod
   onSubmit = att "data-on-submit" . toAction
 
 

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -294,7 +294,7 @@ userForm v = do
     'submit' (border 1) \"Submit\"
 @
 -}
-form :: (Show (Msg id), Form form val, HyperView id) => Msg id -> Mod -> View (FormFields id) () -> View id ()
+form :: (Show (Msg id), Form form val, ViewId id) => Msg id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
 

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -294,14 +294,14 @@ userForm v = do
     'submit' (border 1) \"Submit\"
 @
 -}
-form :: (Show (Msg id), Form form val, ViewId id) => Msg id -> Mod -> View (FormFields id) () -> View id ()
+form :: (Show (Action id), Form form val, ViewId id) => Action id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
 
   tag "form" (onSubmit a . dataTarget vid . md . flexCol) $ do
     addContext (FormFields vid) cnt
  where
-  onSubmit :: (Show (Msg a)) => Msg a -> Mod
+  onSubmit :: (Show (Action a)) => Action a -> Mod
   onSubmit = att "data-on-submit" . toAction
 
 

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -17,8 +17,12 @@ import Web.View
 
 class HasViewId m view where
   viewId :: m view
+
+
 instance HasViewId (View ctx) ctx where
   viewId = context
+
+
 instance HasViewId (Eff (Reader view : es)) view where
   viewId = ask
 
@@ -58,7 +62,14 @@ instance RunHandlers '[] es where
   runHandlers = pure ()
 
 
-instance (Effects view es, Component view es, Read (Action view), RunHandlers views es, ViewId view) => RunHandlers (view : views) es where
+instance
+  ( Component view es
+  , Effects view es
+  , Read (Action view)
+  , RunHandlers views es
+  )
+  => RunHandlers (view : views) es
+  where
   runHandlers = do
     runHandler @view (update @view @es)
     runHandlers @views
@@ -77,7 +88,10 @@ instance (Effects view es, Component view es, Read (Action view), RunHandlers vi
 
 runHandler
   :: forall id es
-   . (Component id es, Read (Action id), ViewId id, Hyperbole :> es)
+   . ( Component id es
+     , Read (Action id)
+     , Hyperbole :> es
+     )
   => (Action id -> Eff (Reader id : es) (View id ()))
   -> Eff es ()
 runHandler run = do
@@ -127,9 +141,9 @@ loadToResponse run = do
 @
 myPage :: (Hyperbole :> es) => UserId -> Page es Response
 myPage userId = do
-  'load' $ do
-    user <- loadUserFromDatabase userId
-    pure $ userPageView user
+ 'load' $ do
+   user <- loadUserFromDatabase userId
+   pure $ userPageView user
 @
 -}
 
@@ -152,18 +166,18 @@ myPage userId = do
 @
 myPage :: ('Hyperbole' :> es) => 'Page' es 'Response'
 myPage = do
-  'handle' messages
-  'load' pageView
+ 'handle' messages
+ 'load' pageView
 
 messages :: ('Hyperbole' :> es, MessageDatabase) => Message -> MessageAction -> 'Eff' es ('View' Message ())
 messages (Message mid) ClearMessage = do
-  deleteMessageSideEffect mid
-  pure $ messageView ""
+ deleteMessageSideEffect mid
+ pure $ messageView ""
 
 messages (Message mid) (Louder m) = do
-  let new = m <> "!"
-  saveMessageSideEffect mid new
-  pure $ messageView new
+ let new = m <> "!"
+ saveMessageSideEffect mid new
+ pure $ messageView new
 @
 -}
 
@@ -172,12 +186,12 @@ messages (Message mid) (Louder m) = do
 @
 myPage :: ('Hyperbole' :> es) => 'Page' es 'Response'
 myPage = do
-  'handle' messages
-  'load' pageView
+ 'handle' messages
+ 'load' pageView
 
 pageView = do
-  el_ "My Page"
-  'hyper' (Message 1) $ messageView "Starting Message"
+ el_ "My Page"
+ 'hyper' (Message 1) $ messageView "Starting Message"
 @
 -}
 

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -66,7 +66,7 @@ instance RunHandlers '[] es where
   runHandlers = pure ()
 
 
-instance (Component view, Read (Msg view), HyperView view, Handle view es, RunHandlers views es) => RunHandlers (view : views) es where
+instance (Component view, Read (Msg view), Handle view es, RunHandlers views es, ViewId view) => RunHandlers (view : views) es where
   runHandlers = do
     runHandler @view (handle @view)
     runHandlers @views
@@ -85,7 +85,7 @@ instance (Component view, Read (Msg view), HyperView view, Handle view es, RunHa
 
 runHandler
   :: forall id es
-   . (Component id, Read (Msg id), HyperView id, Hyperbole :> es)
+   . (Component id, Read (Msg id), ViewId id, Hyperbole :> es)
   => (Msg id -> Eff (Reader id : es) (View id ()))
   -> Eff es ()
 runHandler run = do

--- a/src/Web/Hyperbole/Handler/TypeList.hs
+++ b/src/Web/Hyperbole/Handler/TypeList.hs
@@ -18,8 +18,8 @@ type family ValidDescendents x :: [Type] where
 type family NextDescendents (ex :: [Type]) (xs :: [Type]) where
   NextDescendents _ '[] = '[]
   NextDescendents ex (x ': xs) =
-    RemoveAll (x : ex) (Import x)
-      <++> NextDescendents ((x : ex) <++> Import x) (RemoveAll (x : ex) (Import x))
+    RemoveAll (x : ex) (Require x)
+      <++> NextDescendents ((x : ex) <++> Require x) (RemoveAll (x : ex) (Require x))
       <++> NextDescendents (x : ex) (RemoveAll (x : ex) xs)
 
 
@@ -46,14 +46,14 @@ type NotHandled id ctx (views :: [Type]) =
   TypeError
     ( 'Text "HyperView "
         :<>: 'ShowType id
-        :<>: 'Text " not found in (Import "
+        :<>: 'Text " not found in (Require "
         :<>: 'ShowType ctx
         :<>: 'Text ")"
         :$$: 'Text "  " :<>: 'ShowType views
         :$$: 'Text "Try adding it to the HyperView instance:"
         :$$: 'Text "  instance HyperView " :<>: 'ShowType ctx :<>: 'Text " where"
-        :$$: 'Text "    type Action " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Msg id) :<>: 'Text ""
-        :$$: 'Text "    type Import " :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
+        :$$: 'Text "    type Action " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Action id) :<>: 'Text ""
+        :$$: 'Text "    type Require " :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
     )
 
 
@@ -65,7 +65,7 @@ type NotDesc id ctx x cs =
         :<>: 'ShowType id
         :<>: 'Text ", not handled by context "
         :<>: 'ShowType ctx
-        :$$: ('Text " Import = " ':<>: 'ShowType cs)
+        :$$: ('Text " Require = " ':<>: 'ShowType cs)
         -- ':$$: 'ShowType x
         -- ':$$: 'ShowType cs
     )
@@ -88,7 +88,7 @@ type HyperViewHandled id ctx es =
   ( Component id es
   , Component ctx es
   , -- the id must be found in the children of the context
-    ElemOr id (Import ctx) (NotHandled id ctx (Import ctx))
+    ElemOr id (Require ctx) (NotHandled id ctx (Require ctx))
   , -- Make sure the descendents of id are in the context for the root page
     CheckDescendents id ctx
   )

--- a/src/Web/Hyperbole/Handler/TypeList.hs
+++ b/src/Web/Hyperbole/Handler/TypeList.hs
@@ -85,8 +85,8 @@ type NotInPage x total =
 
 
 type HyperViewHandled id ctx =
-  ( HyperView id
-  , HyperView ctx
+  ( Component id
+  , Component ctx
   , -- the id must be found in the children of the context
     ElemOr id (Import ctx) (NotHandled id ctx (Import ctx))
   , -- Make sure the descendents of id are in the context for the root page

--- a/src/Web/Hyperbole/Handler/TypeList.hs
+++ b/src/Web/Hyperbole/Handler/TypeList.hs
@@ -84,9 +84,9 @@ type NotInPage x total =
     )
 
 
-type HyperViewHandled id ctx =
-  ( Component id
-  , Component ctx
+type HyperViewHandled id ctx es =
+  ( Component id es
+  , Component ctx es
   , -- the id must be found in the children of the context
     ElemOr id (Import ctx) (NotHandled id ctx (Import ctx))
   , -- Make sure the descendents of id are in the context for the root page

--- a/src/Web/Hyperbole/Handler/TypeList.hs
+++ b/src/Web/Hyperbole/Handler/TypeList.hs
@@ -4,6 +4,7 @@ module Web.Hyperbole.Handler.TypeList where
 
 import Data.Kind (Constraint, Type)
 import GHC.TypeLits hiding (Mod)
+import Web.Hyperbole.Component (Component (..))
 import Web.Hyperbole.HyperView
 
 
@@ -17,8 +18,8 @@ type family ValidDescendents x :: [Type] where
 type family NextDescendents (ex :: [Type]) (xs :: [Type]) where
   NextDescendents _ '[] = '[]
   NextDescendents ex (x ': xs) =
-    RemoveAll (x : ex) (Require x)
-      <++> NextDescendents ((x : ex) <++> Require x) (RemoveAll (x : ex) (Require x))
+    RemoveAll (x : ex) (Import x)
+      <++> NextDescendents ((x : ex) <++> Import x) (RemoveAll (x : ex) (Import x))
       <++> NextDescendents (x : ex) (RemoveAll (x : ex) xs)
 
 
@@ -45,14 +46,14 @@ type NotHandled id ctx (views :: [Type]) =
   TypeError
     ( 'Text "HyperView "
         :<>: 'ShowType id
-        :<>: 'Text " not found in (Require "
+        :<>: 'Text " not found in (Import "
         :<>: 'ShowType ctx
         :<>: 'Text ")"
         :$$: 'Text "  " :<>: 'ShowType views
         :$$: 'Text "Try adding it to the HyperView instance:"
         :$$: 'Text "  instance HyperView " :<>: 'ShowType ctx :<>: 'Text " where"
-        :$$: 'Text "    type Action " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Action id) :<>: 'Text ""
-        :$$: 'Text "    type Require " :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
+        :$$: 'Text "    type Action " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Msg id) :<>: 'Text ""
+        :$$: 'Text "    type Import " :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
     )
 
 
@@ -64,7 +65,7 @@ type NotDesc id ctx x cs =
         :<>: 'ShowType id
         :<>: 'Text ", not handled by context "
         :<>: 'ShowType ctx
-        :$$: ('Text " Require = " ':<>: 'ShowType cs)
+        :$$: ('Text " Import = " ':<>: 'ShowType cs)
         -- ':$$: 'ShowType x
         -- ':$$: 'ShowType cs
     )
@@ -87,7 +88,7 @@ type HyperViewHandled id ctx =
   ( HyperView id
   , HyperView ctx
   , -- the id must be found in the children of the context
-    ElemOr id (Require ctx) (NotHandled id ctx (Require ctx))
+    ElemOr id (Import ctx) (NotHandled id ctx (Import ctx))
   , -- Make sure the descendents of id are in the context for the root page
     CheckDescendents id ctx
   )

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -9,28 +9,6 @@ import Text.Read (readMaybe)
 import Web.Hyperbole.Component (Component (..))
 
 
-{- | HyperViews are interactive subsections of a 'Page'
-
-Create an instance with a unique view id type and a sum type describing the actions the HyperView supports. The View Id can contain context (a database id, for example)
-
-@
-data Message = Message Int
-  deriving (Generic, 'Param')
-
-data MessageAction
-  = Louder Text
-  | ClearMessage
-  deriving (Generic, 'Param')
-
-instance HyperView Message where
-  type Action Message = MessageAction
-@
--}
-class (ViewId id) => HyperView id where
-  type Require id :: [Type]
-  type Require id = '[]
-
-
 toAction :: (Show a) => a -> Text
 toAction = pack . show
 
@@ -57,10 +35,6 @@ class ViewId a where
 -- | The top-level view created by 'load'. Carries the views in its type to check that we handled all our views
 data Root (views :: [Type]) = Root
   deriving (Show, Read, ViewId)
-
-
-instance HyperView (Root views) where
-  type Require (Root views) = views
 
 
 instance Component (Root views) where

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -6,6 +6,7 @@ module Web.Hyperbole.HyperView where
 import Data.Kind (Type)
 import Data.Text (Text, pack, unpack)
 import Text.Read (readMaybe)
+import Web.Hyperbole.Component (Component (..))
 
 
 {- | HyperViews are interactive subsections of a 'Page'
@@ -25,27 +26,22 @@ instance HyperView Message where
   type Action Message = MessageAction
 @
 -}
-class (ViewId id, ViewAction (Action id)) => HyperView id where
-  type Action id :: Type
+class (ViewId id) => HyperView id where
   type Require id :: [Type]
   type Require id = '[]
 
 
-class ViewAction a where
-  toAction :: a -> Text
-  default toAction :: (Show a) => a -> Text
-  toAction = pack . show
+toAction :: (Show a) => a -> Text
+toAction = pack . show
 
 
-  parseAction :: Text -> Maybe a
-  default parseAction :: (Read a) => Text -> Maybe a
-  parseAction = readMaybe . unpack
+parseAction :: (Read a) => Text -> Maybe a
+parseAction = readMaybe . unpack
 
 
-instance ViewAction () where
-  toAction _ = ""
-  parseAction _ = Just ()
-
+-- instance ViewAction () where
+--   toAction _ = ""
+--   parseAction _ = Just ()
 
 class ViewId a where
   toViewId :: a -> Text
@@ -64,8 +60,21 @@ data Root (views :: [Type]) = Root
 
 
 instance HyperView (Root views) where
-  type Action (Root views) = ()
   type Require (Root views) = views
+
+
+instance Component (Root views) where
+  data Msg (Root views) = RootMsg
+    deriving (Show, Read)
+
+
+  data Model (Root views) = RootModel
+    deriving (Show, Read)
+
+
+  type Import (Root views) = views
+  render = undefined
+  update = undefined
 
 
 type family TupleList a where

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -1,31 +1,9 @@
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Web.Hyperbole.HyperView where
 
 import Data.Kind (Type)
-import Data.Text (Text, pack, unpack)
-import Text.Read (readMaybe)
-import Web.Hyperbole.Component (Component (..))
-
-
-toAction :: (Show a) => a -> Text
-toAction = pack . show
-
-
-parseAction :: (Read a) => Text -> Maybe a
-parseAction = readMaybe . unpack
-
-
-class ViewId a where
-  toViewId :: a -> Text
-  default toViewId :: (Show a) => a -> Text
-  toViewId = pack . show
-
-
-  parseViewId :: Text -> Maybe a
-  default parseViewId :: (Read a) => Text -> Maybe a
-  parseViewId = readMaybe . unpack
+import Web.Hyperbole.Component (Component (..), IsAction, ViewId)
 
 
 -- | The top-level view created by 'load'. Carries the views in its type to check that we handled all our views
@@ -35,7 +13,7 @@ data Root (views :: [Type]) = Root
 
 instance Component (Root views) es where
   data Action (Root views) = RootAction
-    deriving (Show, Read)
+    deriving (Show, Read, IsAction)
 
 
   data Model (Root views) = RootModel

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -34,7 +34,7 @@ data Root (views :: [Type]) = Root
 
 
 instance Component (Root views) es where
-  data Msg (Root views) = RootMsg
+  data Action (Root views) = RootAction
     deriving (Show, Read)
 
 
@@ -42,7 +42,7 @@ instance Component (Root views) es where
     deriving (Show, Read)
 
 
-  type Import (Root views) = views
+  type Require (Root views) = views
   render _ = pure ()
   update _ = undefined -- TODO: Never called? How to best handle this?
 

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -17,10 +17,6 @@ parseAction :: (Read a) => Text -> Maybe a
 parseAction = readMaybe . unpack
 
 
--- instance ViewAction () where
---   toAction _ = ""
---   parseAction _ = Just ()
-
 class ViewId a where
   toViewId :: a -> Text
   default toViewId :: (Show a) => a -> Text
@@ -47,8 +43,8 @@ instance Component (Root views) es where
 
 
   type Import (Root views) = views
-  render = undefined
-  update = undefined
+  render _ = pure ()
+  update _ = undefined -- TODO: Never called? How to best handle this?
 
 
 type family TupleList a where

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -37,7 +37,7 @@ data Root (views :: [Type]) = Root
   deriving (Show, Read, ViewId)
 
 
-instance Component (Root views) where
+instance Component (Root views) es where
   data Msg (Root views) = RootMsg
     deriving (Show, Read)
 

--- a/src/Web/Hyperbole/View.hs
+++ b/src/Web/Hyperbole/View.hs
@@ -1,10 +1,10 @@
 module Web.Hyperbole.View
-  ( hyper
-  , target
+  ( target
   , module Web.Hyperbole.View.Element
   , module Web.Hyperbole.View.Event
   , module Web.View
-  ) where
+  )
+where
 
 import Web.Hyperbole.View.Element
 import Web.Hyperbole.View.Event

--- a/src/Web/Hyperbole/View/Element.hs
+++ b/src/Web/Hyperbole/View/Element.hs
@@ -3,7 +3,6 @@ module Web.Hyperbole.View.Element where
 import Data.Text (Text, pack)
 import Data.Text qualified as T
 import Web.Hyperbole.Component
-import Web.Hyperbole.HyperView
 import Web.Hyperbole.Route (Route (..), routeUrl)
 import Web.Hyperbole.View.Event (DelayMs)
 import Web.Hyperbole.View.Target (dataTarget)
@@ -14,7 +13,7 @@ import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, labe
 
 > button SomeAction (border 1) "Click Me"
 -}
-button :: (ViewId id, Show (Action id)) => Action id -> Mod -> View id () -> View id ()
+button :: (ViewId id, IsAction (Action id)) => Action id -> Mod -> View id () -> View id ()
 button a f cd = do
   c <- context
   tag "button" (att "data-on-click" (toAction a) . dataTarget c . f) cd
@@ -54,7 +53,7 @@ dropdown act isSel f options = do
 
 -- | An option for a 'dropdown'. First argument is passed to (opt -> Action id) in the 'dropdown', and to the selected predicate
 option
-  :: (ViewId id, Eq opt, Show (Action id))
+  :: (ViewId id, Eq opt, IsAction (Action id))
   => opt
   -> View (Option opt id (Action id)) ()
   -> View (Option opt id (Action id)) ()
@@ -76,14 +75,14 @@ data Option opt id action = Option
 
 
 -- | A live search field
-search :: (ViewId id, Show (Action id)) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
+search :: (ViewId id, IsAction (Action id)) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
 search onInput delay f = do
   c <- context
   tag "input" (att "data-on-input" (toActionInput onInput) . att "data-delay" (pack $ show delay) . dataTarget c . f) none
 
 
 -- | Serialize a constructor that expects a single 'Text', like `data MyAction = GoSearch Text`
-toActionInput :: (Show (Action a)) => (Text -> Action a) -> Text
+toActionInput :: (IsAction (Action a)) => (Text -> Action a) -> Text
 toActionInput con =
   -- remove the ' ""' at the end of the constructor
   T.dropEnd 3 $ toAction $ con ""

--- a/src/Web/Hyperbole/View/Element.hs
+++ b/src/Web/Hyperbole/View/Element.hs
@@ -2,6 +2,7 @@ module Web.Hyperbole.View.Element where
 
 import Data.Text (Text, pack)
 import Data.Text qualified as T
+import Web.Hyperbole.Component
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.Route (Route (..), routeUrl)
 import Web.Hyperbole.View.Event (DelayMs)
@@ -13,7 +14,7 @@ import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, labe
 
 > button SomeAction (border 1) "Click Me"
 -}
-button :: (HyperView id) => Action id -> Mod -> View id () -> View id ()
+button :: (HyperView id, Show (Msg id)) => Msg id -> Mod -> View id () -> View id ()
 button a f cd = do
   c <- context
   tag "button" (att "data-on-click" (toAction a) . dataTarget c . f) cd
@@ -40,10 +41,10 @@ allContactsView fil = do
 -}
 dropdown
   :: (HyperView id)
-  => (opt -> Action id)
+  => (opt -> Msg id)
   -> (opt -> Bool) -- check if selec
   -> Mod
-  -> View (Option opt id (Action id)) ()
+  -> View (Option opt id (Msg id)) ()
   -> View id ()
 dropdown act isSel f options = do
   c <- context
@@ -53,10 +54,10 @@ dropdown act isSel f options = do
 
 -- | An option for a 'dropdown'. First argument is passed to (opt -> Action id) in the 'dropdown', and to the selected predicate
 option
-  :: (HyperView id, Eq opt)
+  :: (HyperView id, Eq opt, Show (Msg id))
   => opt
-  -> View (Option opt id (Action id)) ()
-  -> View (Option opt id (Action id)) ()
+  -> View (Option opt id (Msg id)) ()
+  -> View (Option opt id (Msg id)) ()
 option opt cnt = do
   os <- context
   tag "option" (att "value" (toAction (os.toAction opt)) . selected (os.selected opt)) cnt
@@ -75,14 +76,14 @@ data Option opt id action = Option
 
 
 -- | A live search field
-search :: (HyperView id) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
+search :: (HyperView id, Show (Msg id)) => (Text -> Msg id) -> DelayMs -> Mod -> View id ()
 search onInput delay f = do
   c <- context
   tag "input" (att "data-on-input" (toActionInput onInput) . att "data-delay" (pack $ show delay) . dataTarget c . f) none
 
 
 -- | Serialize a constructor that expects a single 'Text', like `data MyAction = GoSearch Text`
-toActionInput :: (ViewAction a) => (Text -> a) -> Text
+toActionInput :: (Show (Msg a)) => (Text -> Msg a) -> Text
 toActionInput con =
   -- remove the ' ""' at the end of the constructor
   T.dropEnd 3 $ toAction $ con ""

--- a/src/Web/Hyperbole/View/Element.hs
+++ b/src/Web/Hyperbole/View/Element.hs
@@ -14,7 +14,7 @@ import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, labe
 
 > button SomeAction (border 1) "Click Me"
 -}
-button :: (HyperView id, Show (Msg id)) => Msg id -> Mod -> View id () -> View id ()
+button :: (ViewId id, Show (Msg id)) => Msg id -> Mod -> View id () -> View id ()
 button a f cd = do
   c <- context
   tag "button" (att "data-on-click" (toAction a) . dataTarget c . f) cd
@@ -40,7 +40,7 @@ allContactsView fil = do
 @
 -}
 dropdown
-  :: (HyperView id)
+  :: (ViewId id)
   => (opt -> Msg id)
   -> (opt -> Bool) -- check if selec
   -> Mod
@@ -54,7 +54,7 @@ dropdown act isSel f options = do
 
 -- | An option for a 'dropdown'. First argument is passed to (opt -> Action id) in the 'dropdown', and to the selected predicate
 option
-  :: (HyperView id, Eq opt, Show (Msg id))
+  :: (ViewId id, Eq opt, Show (Msg id))
   => opt
   -> View (Option opt id (Msg id)) ()
   -> View (Option opt id (Msg id)) ()
@@ -76,7 +76,7 @@ data Option opt id action = Option
 
 
 -- | A live search field
-search :: (HyperView id, Show (Msg id)) => (Text -> Msg id) -> DelayMs -> Mod -> View id ()
+search :: (ViewId id, Show (Msg id)) => (Text -> Msg id) -> DelayMs -> Mod -> View id ()
 search onInput delay f = do
   c <- context
   tag "input" (att "data-on-input" (toActionInput onInput) . att "data-delay" (pack $ show delay) . dataTarget c . f) none

--- a/src/Web/Hyperbole/View/Element.hs
+++ b/src/Web/Hyperbole/View/Element.hs
@@ -14,7 +14,7 @@ import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, labe
 
 > button SomeAction (border 1) "Click Me"
 -}
-button :: (ViewId id, Show (Msg id)) => Msg id -> Mod -> View id () -> View id ()
+button :: (ViewId id, Show (Action id)) => Action id -> Mod -> View id () -> View id ()
 button a f cd = do
   c <- context
   tag "button" (att "data-on-click" (toAction a) . dataTarget c . f) cd
@@ -41,10 +41,10 @@ allContactsView fil = do
 -}
 dropdown
   :: (ViewId id)
-  => (opt -> Msg id)
+  => (opt -> Action id)
   -> (opt -> Bool) -- check if selec
   -> Mod
-  -> View (Option opt id (Msg id)) ()
+  -> View (Option opt id (Action id)) ()
   -> View id ()
 dropdown act isSel f options = do
   c <- context
@@ -54,10 +54,10 @@ dropdown act isSel f options = do
 
 -- | An option for a 'dropdown'. First argument is passed to (opt -> Action id) in the 'dropdown', and to the selected predicate
 option
-  :: (ViewId id, Eq opt, Show (Msg id))
+  :: (ViewId id, Eq opt, Show (Action id))
   => opt
-  -> View (Option opt id (Msg id)) ()
-  -> View (Option opt id (Msg id)) ()
+  -> View (Option opt id (Action id)) ()
+  -> View (Option opt id (Action id)) ()
 option opt cnt = do
   os <- context
   tag "option" (att "value" (toAction (os.toAction opt)) . selected (os.selected opt)) cnt
@@ -76,14 +76,14 @@ data Option opt id action = Option
 
 
 -- | A live search field
-search :: (ViewId id, Show (Msg id)) => (Text -> Msg id) -> DelayMs -> Mod -> View id ()
+search :: (ViewId id, Show (Action id)) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
 search onInput delay f = do
   c <- context
   tag "input" (att "data-on-input" (toActionInput onInput) . att "data-delay" (pack $ show delay) . dataTarget c . f) none
 
 
 -- | Serialize a constructor that expects a single 'Text', like `data MyAction = GoSearch Text`
-toActionInput :: (Show (Msg a)) => (Text -> Msg a) -> Text
+toActionInput :: (Show (Action a)) => (Text -> Action a) -> Text
 toActionInput con =
   -- remove the ' ""' at the end of the constructor
   T.dropEnd 3 $ toAction $ con ""

--- a/src/Web/Hyperbole/View/Event.hs
+++ b/src/Web/Hyperbole/View/Event.hs
@@ -19,7 +19,7 @@ pollMessageView m = do
     'el_' ('text' m)
 @
 -}
-onLoad :: (Show (Msg id), ViewId id) => Msg id -> DelayMs -> View id () -> View id ()
+onLoad :: (Show (Action id), ViewId id) => Action id -> DelayMs -> View id () -> View id ()
 onLoad a delay initContent = do
   c <- context
   el (att "data-on-load" (toAction a) . att "data-delay" (pack $ show delay) . dataTarget c) initContent

--- a/src/Web/Hyperbole/View/Event.hs
+++ b/src/Web/Hyperbole/View/Event.hs
@@ -1,6 +1,7 @@
 module Web.Hyperbole.View.Event where
 
 import Data.Text (pack)
+import Web.Hyperbole.Component (Component (..))
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.View.Target
 import Web.View (View, att, context, el, flexCol, hide, parent)
@@ -19,7 +20,7 @@ pollMessageView m = do
     'el_' ('text' m)
 @
 -}
-onLoad :: (HyperView id) => Action id -> DelayMs -> View id () -> View id ()
+onLoad :: (Show (Msg id), HyperView id) => Msg id -> DelayMs -> View id () -> View id ()
 onLoad a delay initContent = do
   c <- context
   el (att "data-on-load" (toAction a) . att "data-delay" (pack $ show delay) . dataTarget c) initContent

--- a/src/Web/Hyperbole/View/Event.hs
+++ b/src/Web/Hyperbole/View/Event.hs
@@ -1,7 +1,6 @@
 module Web.Hyperbole.View.Event where
 
 import Data.Text (pack)
-import Web.Hyperbole.Component (Component (..))
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.View.Target
 import Web.View (View, att, context, el, flexCol, hide, parent)
@@ -20,7 +19,7 @@ pollMessageView m = do
     'el_' ('text' m)
 @
 -}
-onLoad :: (Show (Msg id), HyperView id) => Msg id -> DelayMs -> View id () -> View id ()
+onLoad :: (Show (Msg id), ViewId id) => Msg id -> DelayMs -> View id () -> View id ()
 onLoad a delay initContent = do
   c <- context
   el (att "data-on-load" (toAction a) . att "data-delay" (pack $ show delay) . dataTarget c) initContent

--- a/src/Web/Hyperbole/View/Event.hs
+++ b/src/Web/Hyperbole/View/Event.hs
@@ -1,6 +1,7 @@
 module Web.Hyperbole.View.Event where
 
 import Data.Text (pack)
+import Web.Hyperbole.Component (IsAction (..), ViewId)
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.View.Target
 import Web.View (View, att, context, el, flexCol, hide, parent)
@@ -19,7 +20,7 @@ pollMessageView m = do
     'el_' ('text' m)
 @
 -}
-onLoad :: (Show (Action id), ViewId id) => Action id -> DelayMs -> View id () -> View id ()
+onLoad :: (IsAction (Action id), ViewId id) => Action id -> DelayMs -> View id () -> View id ()
 onLoad a delay initContent = do
   c <- context
   el (att "data-on-load" (toAction a) . att "data-delay" (pack $ show delay) . dataTarget c) initContent

--- a/src/Web/Hyperbole/View/Target.hs
+++ b/src/Web/Hyperbole/View/Target.hs
@@ -61,5 +61,5 @@ dataTarget = att "data-target" . toViewId
 >     el_ "Now we can trigger a MessageAction which will update our Message HyperView, not this one"
 >     button ClearMessage id "Clear Message #2"
 -}
-target :: (HyperView id) => id -> View id () -> View a ()
+target :: (Component id) => id -> View id () -> View a ()
 target = addContext

--- a/src/Web/Hyperbole/View/Target.hs
+++ b/src/Web/Hyperbole/View/Target.hs
@@ -2,8 +2,7 @@
 
 module Web.Hyperbole.View.Target where
 
-import Web.Hyperbole.Component (Component (..))
-import Web.Hyperbole.HyperView
+import Web.Hyperbole.Component (Component (..), ViewId (..))
 import Web.View (Mod, View, addContext, att, el, flexCol)
 
 

--- a/src/Web/Hyperbole/View/Target.hs
+++ b/src/Web/Hyperbole/View/Target.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module Web.Hyperbole.View.Target where
 
 import Web.Hyperbole.Component (Component (..))
@@ -39,7 +41,7 @@ otherView = do
 -- AND all their children have to be there
 -- , All (Elem (Require ctx)) (Require id)
 
-hyperUnsafe :: (ViewId c, Component c) => c -> View c () -> View ctx ()
+hyperUnsafe :: (ViewId c, Component c es) => c -> View c () -> View ctx ()
 hyperUnsafe vid vw = do
   el (att "id" (toViewId vid) . flexCol) $
     addContext vid vw
@@ -61,5 +63,5 @@ dataTarget = att "data-target" . toViewId
 >     el_ "Now we can trigger a MessageAction which will update our Message HyperView, not this one"
 >     button ClearMessage id "Clear Message #2"
 -}
-target :: (Component id) => id -> View id () -> View a ()
+target :: (Component id es) => id -> View id () -> View a ()
 target = addContext

--- a/src/Web/Hyperbole/View/Target.hs
+++ b/src/Web/Hyperbole/View/Target.hs
@@ -1,6 +1,6 @@
 module Web.Hyperbole.View.Target where
 
-import Web.Hyperbole.Handler.TypeList (HyperViewHandled)
+import Web.Hyperbole.Component (Component (..))
 import Web.Hyperbole.HyperView
 import Web.View (Mod, View, addContext, att, el, flexCol)
 
@@ -38,16 +38,8 @@ otherView = do
 -- TODO: if I'm going to limit it, it's going to happen here
 -- AND all their children have to be there
 -- , All (Elem (Require ctx)) (Require id)
-hyper
-  :: forall id ctx
-   . (HyperViewHandled id ctx)
-  => id
-  -> View id ()
-  -> View ctx ()
-hyper = hyperUnsafe
 
-
-hyperUnsafe :: (ViewId id) => id -> View id () -> View ctx ()
+hyperUnsafe :: (ViewId c, Component c) => c -> View c () -> View ctx ()
 hyperUnsafe vid vw = do
   el (att "id" (toViewId vid) . flexCol) $
     addContext vid vw


### PR DESCRIPTION
Hey @seanhess, I am pretty excited to share a new experimental way of writing apps using `hyperbole`. I think it might be easier for newcomers since it groups everything one needs in one convenient typeclass called `Component`.

Without further ado, here's how the `Simple.hs` example looks like using this new approach:

```hs
page :: (Hyperbole :> es, Concurrent :> es, Reader (TVar Int) :> es) => Page es '[Counter]
page = do
  var <- ask
  n <- readTVarIO var
  pure $ col (pad 20 . gap 10) $ do
    el id "Counter"
    start Counter CounterModel{count = n}

data Counter = Counter
  deriving (Show, Read, ViewId)

instance Component Counter es where
  data Model Counter = CounterModel
    { count :: Int
    }

  data Action Counter
    = Increment
    | Decrement
    deriving (Show, Read, IsAction)

  -- Add additional effects required by the component. Can be omitted if there are none.
  type Effects Counter es = (Reader (TVar Int) :> es, Concurrent :> es)

  render :: Model Counter -> View Counter ()
  render model = col (gap 10) $ do
    row id $ do
      el (bold . fontSize 48 . border 1 . pad (XY 20 0)) $ text $ pack $ show model.count
    row (gap 10) $ do
      button Decrement id "Decrement"
      button Increment id "Increment"


  -- Ideally the update function would only run effects and update the model without having to render the view manually. Its signature could change to receive the previous model and the action instead of just the action.
  update = \case
    Increment -> do
      -- Inside the update function we have access to the effects defined in the
      -- associated type 'Effects c es':
      n <- modify $ \n -> n + 1
      pure $ render $ CounterModel{count = n}
    Decrement -> do
      n <- modify $ \n -> n - 1
      pure $ render $ CounterModel{count = n}

```

The class itself looks like this:

```hs
-- | A 'Component' is a self-contained piece of a 'Page'.
class (ViewId c, IsAction (Action c)) => Component c es where
  -- | The data used by the component.
  data Model c

  -- | The actions supported by the component.
  data Action c

  -- | Additional effects required by the component. Can be omitted.
  type Effects c (es :: [Effect]) :: Constraint
  type Effects c es = ()

  -- | Other components nested in the component. Can be omitted.
  type Require c :: [Type]
  type Require c = '[]

  -- | Render the component.
  render :: Model c -> View c ()

  -- | Update the component based on a message. Ideally would only change the data model and leave rendering to the 'render' function.
  update :: (Effects c es) => Action c -> Eff (Reader c : es) (View c ())
```
In essence, we now need to declare the component id like before, deriving `ViewId` and giving it a `Component` instance. The user no longer needs to worry about `HyperView` and `Handler` classes.

### More examples
I added a [`Nested.hs`](https://github.com/seanhess/hyperbole/pull/47/files#diff-c611a4ea41f8579edcdc7cedce5e66f2935810e7c25f9c30d82826bebb4c020b) file next to the `Simple.hs` example to showcase the nested approach using `Require`. 

I also have a repository using this version that reimplements all examples using this new style (well, a couple of them - still working on the others) that I can share with you once it's in a more ready state.

### Issues/TODOs
- I couldn't get the tests to run locally but I can work on adjusting them (and the examples) if you think this is a good approach
- I couldn't figure out how to make `delegate` function work (but also didn't spend so much time on it) :shrug:.

Anyway, I'd love to hear your thoughts about this!