### PR TITLE
data family Action

### DIFF
--- a/example/Example/AppRoute.hs
+++ b/example/Example/AppRoute.hs
@@ -1,7 +1,8 @@
 module Example.AppRoute where
 
-import Data.Text (Text)
+import Data.Text (Text, unpack)
 import Example.Effects.Users (UserId)
+import Text.Read (readMaybe)
 import Web.Hyperbole
 
 
@@ -32,6 +33,12 @@ data ContactRoute
   deriving (Eq, Generic)
 instance Route ContactRoute where
   baseRoute = Just ContactsAll
+  matchRoute [] = pure ContactsAll
+  matchRoute [""] = pure ContactsAll
+  matchRoute [contactId] = do
+    cid <- readMaybe $ unpack contactId
+    pure $ Contact cid
+  matchRoute _ = Nothing
 
 
 data Hello

--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -20,13 +20,12 @@ data Contents = Contents Milliseconds
   deriving (Show, Read, ViewId)
 
 
-data ContentsAction
-  = Load Int
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Contents where
-  type Action Contents = ContentsAction
+  data Action Contents
+    = Load Int
+    deriving (Show, Read, ViewAction)
+
+
 instance (Debug :> es) => Handle Contents es where
   handle (Load n) = do
     Contents dl <- viewId

--- a/example/Example/Counter.hs
+++ b/example/Example/Counter.hs
@@ -22,14 +22,11 @@ data Counter = Counter
   deriving (Show, Read, ViewId)
 
 
-data Count
-  = Increment
-  | Decrement
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Counter where
-  type Action Counter = Count
+  data Action Counter
+    = Increment
+    | Decrement
+    deriving (Show, Read, ViewAction)
 instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
   handle Increment = do
     n <- modify (+ 1)

--- a/example/Example/Errors.hs
+++ b/example/Example/Errors.hs
@@ -17,13 +17,12 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-data ContentsAction
-  = CauseError
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Contents where
-  type Action Contents = ContentsAction
+  data Action Contents
+    = CauseError
+    deriving (Show, Read, ViewAction)
+
+
 instance Handle Contents es where
   handle CauseError = do
     -- Return a not found error 404

--- a/example/Example/Forms.hs
+++ b/example/Example/Forms.hs
@@ -17,12 +17,12 @@ data FormView = FormView
   deriving (Show, Read, ViewId)
 
 
-data FormAction = Submit
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView FormView where
-  type Action FormView = FormAction
+  data Action FormView
+    = Submit
+    deriving (Show, Read, ViewAction)
+
+
 instance Handle FormView es where
   handle Submit = do
     uf <- formData @UserForm

--- a/example/Example/LazyLoading.hs
+++ b/example/Example/LazyLoading.hs
@@ -20,13 +20,10 @@ page = do
 data Contents = Contents
   deriving (Show, Read, ViewId)
 instance HyperView Contents where
-  type Action Contents = ContentsAction
-
-
-data ContentsAction
-  = Load
-  | Reload Int
-  deriving (Show, Read, ViewAction)
+  data Action Contents
+    = Load
+    | Reload Int
+    deriving (Show, Read, ViewAction)
 
 
 instance (Debug :> es) => Handle Contents es where

--- a/example/Example/Redirects.hs
+++ b/example/Example/Redirects.hs
@@ -15,13 +15,10 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-data ContentsAction
-  = RedirectAsAction
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Contents where
-  type Action Contents = ContentsAction
+  data Action Contents
+    = RedirectAsAction
+    deriving (Show, Read, ViewAction)
 instance Handle Contents es where
   handle RedirectAsAction = do
     redirect "/hello/redirected"

--- a/example/Example/Search.hs
+++ b/example/Example/Search.hs
@@ -19,13 +19,13 @@ data LiveSearch = LiveSearch
 
 
 data SearchAction
-  = GoSearch Text
-  | Select ProgrammingLanguage
-  deriving (Show, Read, ViewAction)
 
 
 instance HyperView LiveSearch where
-  type Action LiveSearch = SearchAction
+  data Action LiveSearch
+    = GoSearch Text
+    | Select ProgrammingLanguage
+    deriving (Show, Read, ViewAction)
 instance Handle LiveSearch es where
   handle (GoSearch term) = do
     let matched = filter (isMatchLanguage term) allLanguages

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -28,14 +28,12 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-data ContentsAction
-  = SaveColor AppColor
-  | SaveMessage Text
-  deriving (Show, Read, ViewAction)
-
 
 instance HyperView Contents where
-  type Action Contents = ContentsAction
+  data Action Contents
+    = SaveColor AppColor
+    | SaveMessage Text
+    deriving (Show, Read, ViewAction)
 instance (Debug :> es) => Handle Contents es where
   handle (SaveColor clr) = do
     setSession "color" clr

--- a/example/Example/Simple.hs
+++ b/example/Example/Simple.hs
@@ -26,12 +26,12 @@ data Message = Message Int
   deriving (Show, Read, ViewId)
 
 
-data MessageAction = Louder Text
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Message where
-  type Action Message = MessageAction
+  data Action Message
+    = Louder Text
+    deriving (Show, Read, ViewAction)
+
+
 instance Handle Message es where
   handle (Louder m) = do
     let new = m <> "!"

--- a/example/Example/Transitions.hs
+++ b/example/Example/Transitions.hs
@@ -16,13 +16,13 @@ data Contents = Contents
 
 
 data ContentsAction
-  = Expand
-  | Collapse
-  deriving (Show, Read, ViewAction)
 
 
 instance HyperView Contents where
-  type Action Contents = ContentsAction
+  data Action Contents
+    = Expand
+    | Collapse
+    deriving (Show, Read, ViewAction)
 instance Handle Contents es where
   handle Expand = do
     pure viewBig

--- a/example/HelloWorld.hs
+++ b/example/HelloWorld.hs
@@ -14,12 +14,12 @@ data Message = Message
   deriving (Show, Read, ViewId)
 
 
-data MessageAction = SetMessage Text
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Message where
-  type Action Message = MessageAction
+  data Action Message
+    = SetMessage Text
+    deriving (Show, Read, ViewAction)
+
+
 instance Handle Message es where
   handle (SetMessage m) = do
     -- side effects

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -36,14 +36,11 @@ data Counter = Counter
   deriving (Show, Read, ViewId)
 
 
-data Count
-  = Increment
-  | Decrement
-  deriving (Show, Read, ViewAction)
-
-
 instance HyperView Counter where
-  type Action Counter = Count
+  data Action Counter
+    = Increment
+    | Decrement
+    deriving (Show, Read, ViewAction)
 
 
 instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -37,6 +37,7 @@ module Web.Hyperbole.Forms
   )
 where
 
+import Data.Function ((&))
 import Data.Functor.Identity (Identity (..))
 import Data.Kind (Type)
 import Data.Text (Text, pack)
@@ -50,6 +51,7 @@ import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.View.Target (dataTarget)
 import Web.View hiding (form, input, label)
+import Web.View.Style (addClass, cls, prop)
 
 
 -- | The only time we can use Fields is inside a form
@@ -297,12 +299,17 @@ userForm v = do
 form :: (Form form val, HyperView id) => Action id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
-
-  tag "form" (onSubmit a . dataTarget vid . md . flexCol) $ do
+  tag "form" (onSubmit a . dataTarget vid . md . flexCol . marginEnd0) $ do
     addContext (FormFields vid) cnt
  where
   onSubmit :: (ViewAction a) => a -> Mod
   onSubmit = att "data-on-submit" . toAction
+
+  -- not sure why chrome is adding margin-block-end: 16 to forms? Add to web-view?
+  marginEnd0 =
+    addClass $
+      cls "mg-end-0"
+        & prop @PxRem "margin-block-end" 0
 
 
 -- | Button that submits the 'form'. Use 'button' to specify actions other than submit

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -29,26 +29,6 @@ instance HasViewId (Eff (Reader view : es)) view where
 type Handler es view a = Eff (Reader view : es) a
 
 
--- If the actions are the same (newtype), map the views and have the inner handler process it
-delegate
-  :: forall view inner es
-   . (Action view ~ Action inner, Handle inner (Reader view : es), Hyperbole :> es)
-  => (view -> inner)
-  -> Action view
-  -> Eff (Reader view : es) (View view ())
-delegate f action = do
-  c <- viewId
-  let inner = f c
-  innerView <- runReader inner $ handle @inner action
-  pure $ addContext inner innerView
-
-
-mapView :: (view -> inner) -> View inner () -> View view ()
-mapView f inner = do
-  view1 <- viewId
-  addContext (f view1) inner
-
-
 -- class SetContext (f :: Type -> Type -> Type) es cnew cold where
 --   setViewId :: cnew -> (f es) cnew () -> (f es) cold ()
 -- instance SetContext (View Identity) a b where

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -26,7 +26,7 @@ instance HyperView Message where
 @
 -}
 class (ViewId id, ViewAction (Action id)) => HyperView id where
-  type Action id :: Type
+  data Action id :: Type
   type Require id :: [Type]
   type Require id = '[]
 
@@ -64,7 +64,8 @@ data Root (views :: [Type]) = Root
 
 
 instance HyperView (Root views) where
-  type Action (Root views) = ()
+  data Action (Root views) = RootNone
+    deriving (Show, Read, ViewAction)
   type Require (Root views) = views
 
 


### PR DESCRIPTION
As shown by @cgeorgii in #47, we can use a data family instead of a type family to encourage users to define actions inline. This means they don't have to think of a name for that type (which was always annoying). 

It also discourages reuse of action types. After some thought, I'd like to really encourage use of view functions, and remove `delegate`. See Example.Contacts and Example.Contact for an example. 

Before: 

```
data ContactAction
    = Reload (Maybe Filter)
    | AddUser
    | DeleteUser UserId
    deriving (Show, Read, ViewAction)

instance HyperView Contacts where
  type Action Contacts = ContactAction
  type Require Contacts = '[InlineContact]
```

After

```
instance HyperView Contacts where
  data Action Contacts
    = Reload (Maybe Filter)
    | AddUser
    | DeleteUser UserId
    deriving (Show, Read, ViewAction)
  type Require Contacts = '[InlineContact]
```