### PR TITLE
Unify HyperView and Handler typeclass

### DIFF
--- a/example/Example/Concurrent.hs
+++ b/example/Example/Concurrent.hs
@@ -8,33 +8,30 @@ import Example.Effects.Debug
 import Web.Hyperbole
 
 
-page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es '[Contents]
+page :: (Hyperbole :> es, Debug :> es, IOE :> es) => Page es '[Poller]
 page = do
   pure $ do
     col (pad 20) $ do
-      hyper (Contents 50) $ viewPoll 1
-      hyper (Contents 1000) $ viewPoll 100
+      hyper (Poller 50) $ viewPoll 1
+      hyper (Poller 1000) $ viewPoll 100
 
 
-data Contents = Contents Milliseconds
+data Poller = Poller Milliseconds
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Contents where
-  data Action Contents
+instance (Debug :> es) => HyperView Poller es where
+  data Action Poller
     = Load Int
     deriving (Show, Read, ViewAction)
-
-
-instance (Debug :> es) => Handle Contents es where
   handle (Load n) = do
-    Contents dl <- viewId
+    Poller dl <- viewId
     -- BUG: this is blocking the thread, so the short poll has to wait for the long to finish before continuing
     delay dl
     pure $ viewPoll (n + 1)
 
 
-viewPoll :: Int -> View Contents ()
+viewPoll :: Int -> View Poller ()
 viewPoll n = do
   onLoad (Load n) 0 $ do
     row (gap 10) $ do

--- a/example/Example/Contact.hs
+++ b/example/Example/Contact.hs
@@ -38,15 +38,12 @@ data Contact = Contact UserId
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Contact where
+instance (Users :> es, Debug :> es) => HyperView Contact es where
   data Action Contact
     = Edit
     | Save
     | View
     deriving (Show, Read, ViewAction)
-
-
-instance (Users :> es, Debug :> es) => Handle Contact es where
   handle action = do
     -- No matter which action we are performing, let's look up the user to make sure it exists
     Contact uid <- viewId
@@ -82,7 +79,7 @@ contactView :: User -> View Contact ()
 contactView = contactView' Edit
 
 
-contactView' :: (HyperView c) => Action c -> User -> View c ()
+contactView' :: (ViewId c, ViewAction (Action c)) => Action c -> User -> View c ()
 contactView' edit u = do
   col (gap 10) $ do
     row fld $ do
@@ -110,7 +107,7 @@ contactEdit :: User -> View Contact ()
 contactEdit u = onRequest contactLoading $ contactEdit' View Save u
 
 
-contactEdit' :: (HyperView c) => Action c -> Action c -> User -> View c ()
+contactEdit' :: (ViewId c, ViewAction (Action c)) => Action c -> Action c -> User -> View c ()
 contactEdit' onView onSave u = do
   contactForm onSave contactFromUser
   col (gap 10) $ do
@@ -125,7 +122,7 @@ contactEdit' onView onSave u = do
       }
 
 
-contactForm :: (HyperView id) => Action id -> ContactForm Maybe -> View id ()
+contactForm :: (ViewId id, ViewAction (Action id)) => Action id -> ContactForm Maybe -> View id ()
 contactForm onSubmit c = do
   let f = genFieldsWith c
   form @ContactForm onSubmit (gap 10) $ do

--- a/example/Example/Contacts.hs
+++ b/example/Example/Contacts.hs
@@ -38,14 +38,13 @@ data Filter
   deriving (Eq, Show, Read)
 
 
-instance HyperView Contacts where
+instance (Users :> es, Debug :> es) => HyperView Contacts es where
   data Action Contacts
     = Reload (Maybe Filter)
     | AddUser
     | DeleteUser UserId
     deriving (Show, Read, ViewAction)
   type Require Contacts = '[InlineContact]
-instance (Users :> es, Debug :> es) => Handle Contacts es where
   handle = \case
     Reload mf -> do
       us <- Users.all
@@ -105,13 +104,17 @@ data InlineContact = InlineContact UserId
   deriving (Show, Read, ViewId)
 
 
-instance HyperView InlineContact where
+instance (Users :> es, Debug :> es) => HyperView InlineContact es where
   data Action InlineContact
     = Edit
     | View
     | Save
     deriving (Show, Read, ViewAction)
-instance (Users :> es, Debug :> es) => Handle InlineContact es where
+
+
+  type Require InlineContact = '[Contacts]
+
+
   handle action = do
     InlineContact uid <- viewId
     u <- Users.find uid

--- a/example/Example/Counter.hs
+++ b/example/Example/Counter.hs
@@ -22,12 +22,13 @@ data Counter = Counter
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Counter where
+instance (Reader (TVar Int) :> es, Concurrent :> es) => HyperView Counter es where
   data Action Counter
     = Increment
     | Decrement
     deriving (Show, Read, ViewAction)
-instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
+
+
   handle Increment = do
     n <- modify (+ 1)
     pure $ viewCount n

--- a/example/Example/Errors.hs
+++ b/example/Example/Errors.hs
@@ -17,13 +17,12 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Contents where
+instance HyperView Contents es where
   data Action Contents
     = CauseError
     deriving (Show, Read, ViewAction)
 
 
-instance Handle Contents es where
   handle CauseError = do
     -- Return a not found error 404
     notFound
@@ -33,3 +32,5 @@ viewContent :: View Contents ()
 viewContent = do
   col (gap 10 . pad 20) $ do
     button CauseError Style.btn "Not Found Error"
+
+-- Compile Errors (Uncomment)

--- a/example/Example/Forms.hs
+++ b/example/Example/Forms.hs
@@ -17,13 +17,12 @@ data FormView = FormView
   deriving (Show, Read, ViewId)
 
 
-instance HyperView FormView where
+instance HyperView FormView es where
   data Action FormView
     = Submit
     deriving (Show, Read, ViewAction)
 
 
-instance Handle FormView es where
   handle Submit = do
     uf <- formData @UserForm
 

--- a/example/Example/LazyLoading.hs
+++ b/example/Example/LazyLoading.hs
@@ -19,14 +19,13 @@ page = do
 
 data Contents = Contents
   deriving (Show, Read, ViewId)
-instance HyperView Contents where
+
+
+instance (Debug :> es) => HyperView Contents es where
   data Action Contents
     = Load
     | Reload Int
     deriving (Show, Read, ViewAction)
-
-
-instance (Debug :> es) => Handle Contents es where
   handle Load = do
     -- Pretend the initial Load takes 1s to complete
     delay 1000

--- a/example/Example/Redirects.hs
+++ b/example/Example/Redirects.hs
@@ -15,11 +15,9 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Contents where
-  data Action Contents
-    = RedirectAsAction
+instance HyperView Contents es where
+  data Action Contents = RedirectAsAction
     deriving (Show, Read, ViewAction)
-instance Handle Contents es where
   handle RedirectAsAction = do
     redirect "/hello/redirected"
 

--- a/example/Example/Search.hs
+++ b/example/Example/Search.hs
@@ -18,15 +18,13 @@ data LiveSearch = LiveSearch
   deriving (Show, Read, ViewId)
 
 
-data SearchAction
-
-
-instance HyperView LiveSearch where
+instance HyperView LiveSearch es where
   data Action LiveSearch
     = GoSearch Text
     | Select ProgrammingLanguage
     deriving (Show, Read, ViewAction)
-instance Handle LiveSearch es where
+
+
   handle (GoSearch term) = do
     let matched = filter (isMatchLanguage term) allLanguages
     pure $ liveSearchView matched Nothing

--- a/example/Example/Sessions.hs
+++ b/example/Example/Sessions.hs
@@ -28,13 +28,11 @@ data Contents = Contents
   deriving (Show, Read, ViewId)
 
 
-
-instance HyperView Contents where
+instance (Debug :> es) => HyperView Contents es where
   data Action Contents
     = SaveColor AppColor
     | SaveMessage Text
     deriving (Show, Read, ViewAction)
-instance (Debug :> es) => Handle Contents es where
   handle (SaveColor clr) = do
     setSession "color" clr
     msg <- session "msg"

--- a/example/Example/Simple.hs
+++ b/example/Example/Simple.hs
@@ -26,13 +26,11 @@ data Message = Message Int
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Message where
-  data Action Message
-    = Louder Text
+
+
+instance HyperView Message es where
+  data Action Message = Louder Text
     deriving (Show, Read, ViewAction)
-
-
-instance Handle Message es where
   handle (Louder m) = do
     let new = m <> "!"
     pure $ messageView new

--- a/example/Example/Transitions.hs
+++ b/example/Example/Transitions.hs
@@ -18,12 +18,11 @@ data Contents = Contents
 data ContentsAction
 
 
-instance HyperView Contents where
+instance HyperView Contents es where
   data Action Contents
     = Expand
     | Collapse
     deriving (Show, Read, ViewAction)
-instance Handle Contents es where
   handle Expand = do
     pure viewBig
   handle Collapse = do

--- a/example/HelloWorld.hs
+++ b/example/HelloWorld.hs
@@ -14,13 +14,9 @@ data Message = Message
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Message where
-  data Action Message
-    = SetMessage Text
+instance HyperView Message es where
+  data Action Message = SetMessage Text
     deriving (Show, Read, ViewAction)
-
-
-instance Handle Message es where
   handle (SetMessage m) = do
     -- side effects
     pure $ messageView' m

--- a/src/Simple.hs
+++ b/src/Simple.hs
@@ -36,14 +36,13 @@ data Counter = Counter
   deriving (Show, Read, ViewId)
 
 
-instance HyperView Counter where
+instance (Reader (TVar Int) :> es, Concurrent :> es) => HyperView Counter es where
   data Action Counter
     = Increment
     | Decrement
     deriving (Show, Read, ViewAction)
 
 
-instance (Reader (TVar Int) :> es, Concurrent :> es) => Handle Counter es where
   handle Increment = do
     Counter <- viewId
     n <- modify $ \n -> n + 1

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -43,6 +43,8 @@ module Web.Hyperbole
     -- ** HyperView
   , HyperView (..)
   , hyper
+  , viewId
+  , Page
 
     -- * Interactive Elements
 
@@ -82,9 +84,6 @@ module Web.Hyperbole
   , InputType (..)
 
     -- ** Handlers
-  , Handle (..)
-  , viewId
-  , Page
 
     -- ** Validation
   , Validated (..)
@@ -156,7 +155,7 @@ import Web.Hyperbole.Effect.Server
 import Web.Hyperbole.Embed
 import Web.Hyperbole.Forms
 import Web.Hyperbole.Handler
-import Web.Hyperbole.Handler.TypeList
+import Web.Hyperbole.Handler.TypeList ()
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.Page (Page, runPage)
 import Web.Hyperbole.Route

--- a/src/Web/Hyperbole/Effect/Hyperbole.hs
+++ b/src/Web/Hyperbole/Effect/Hyperbole.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Web.Hyperbole.Effect.Hyperbole where
 
 import Control.Monad (join)
 import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
+import Data.Kind (Constraint, Type)
 import Data.List qualified as List
 import Data.Maybe (isJust)
 import Data.String.Conversions
@@ -13,14 +15,16 @@ import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Effectful
 import Effectful.Dispatch.Dynamic
 import Effectful.Error.Static
+import Effectful.Reader.Dynamic
 import Effectful.State.Static.Local
+import GHC.TypeLits hiding (Mod)
 import Web.FormUrlEncoded (Form, urlDecodeForm)
 import Web.HttpApiData (FromHttpApiData, ToHttpApiData (..), parseQueryParam)
 import Web.Hyperbole.Effect.Server
+import Web.Hyperbole.Handler.TypeList
 import Web.Hyperbole.HyperView
 import Web.Hyperbole.Route
 import Web.Hyperbole.Session as Session
-import Web.Hyperbole.View.Target (hyperUnsafe)
 import Web.View
 
 
@@ -110,18 +114,14 @@ formBody = do
   either (send . RespondEarly . Err . ErrParse) pure ef
 
 
-getEvent :: (HyperView id, Hyperbole :> es) => Eff es (Maybe (Event id (Action id)))
+getEvent :: (HyperView id es, Hyperbole :> es) => Eff es (Maybe (Event id (Action id)))
 getEvent = do
   q <- reqParams
-  pure $ parseEvent q
-
-
-parseEvent :: (HyperView id) => Query -> Maybe (Event id (Action id))
-parseEvent q = do
-  Event ti ta <- lookupEvent q
-  vid <- parseViewId ti
-  act <- parseAction ta
-  pure $ Event vid act
+  pure $ do
+    Event ti ta <- lookupEvent q
+    vid <- parseViewId ti
+    act <- parseAction ta
+    pure $ Event vid act
 
 
 lookupEvent :: Query -> Maybe (Event Text Text)
@@ -245,7 +245,7 @@ redirect = send . RespondEarly . Redirect
 
 
 -- | Respond with the given view, and stop execution
-respondEarly :: (Hyperbole :> es, HyperView id) => id -> View id () -> Eff es ()
+respondEarly :: (Hyperbole :> es, HyperView id es) => id -> View id () -> Eff es ()
 respondEarly i vw = do
   let vid = TargetViewId (toViewId i)
   let res = Response vid $ hyperUnsafe i vw
@@ -256,3 +256,170 @@ respondEarly i vw = do
 view :: (Hyperbole :> es) => View () () -> Eff es Response
 view vw = do
   pure $ Response (TargetViewId "") vw
+
+
+{- | HyperViews are interactive subsections of a 'Page'
+
+Create an instance with a unique view id type and a sum type describing the actions the HyperView supports. The View Id can contain context (a database id, for example)
+
+@
+data Message = Message Int
+  deriving (Generic, 'Param')
+
+data MessageAction
+  = Louder Text
+  | ClearMessage
+  deriving (Generic, 'Param')
+
+instance HyperView Message where
+  type Action Message = MessageAction
+@
+-}
+class (ViewId id, ViewAction (Action id)) => HyperView id es where
+  data Action id
+
+
+  type Require id :: [Type]
+  type Require id = '[]
+
+
+  handle :: (Hyperbole :> es) => Action id -> Eff (Reader id : es) (View id ())
+
+
+-- | The top-level view created by 'load'. Carries the views in its type to check that we handled all our views
+data Root (views :: [Type]) = Root
+  deriving (Show, Read, ViewId)
+
+
+instance HyperView (Root views) es where
+  data Action (Root views) = RootNone
+    deriving (Show, Read, ViewAction)
+  type Require (Root views) = views
+  handle _ = pure none
+
+
+type family ValidDescendents x :: [Type] where
+  ValidDescendents x = x : NextDescendents '[] '[x]
+
+
+type family NextDescendents (ex :: [Type]) (xs :: [Type]) where
+  NextDescendents _ '[] = '[]
+  NextDescendents ex (x ': xs) =
+    RemoveAll (x : ex) (Require x)
+      <++> NextDescendents ((x : ex) <++> Require x) (RemoveAll (x : ex) (Require x))
+      <++> NextDescendents (x : ex) (RemoveAll (x : ex) xs)
+
+
+type NotHandled id ctx (views :: [Type]) =
+  TypeError
+    ( 'Text "HyperView "
+        :<>: 'ShowType id
+        :<>: 'Text " not found in (Require "
+        :<>: 'ShowType ctx
+        :<>: 'Text ")"
+        :$$: 'Text "  "
+          :<>: 'ShowType views
+        :$$: 'Text "Try adding it to the HyperView instance:"
+        :$$: 'Text "  instance HyperView "
+          :<>: 'ShowType ctx
+          :<>: 'Text " where"
+        :$$: 'Text "    type Action "
+          :<>: 'ShowType ctx
+          :<>: 'Text " = "
+          :<>: ShowType (Action id)
+          :<>: 'Text ""
+        :$$: 'Text "    type Require "
+          :<>: 'ShowType ctx
+          :<>: 'Text " = ["
+          :<>: ShowType id
+          :<>: 'Text ", ...]"
+    )
+
+
+type NotDesc id ctx x cs =
+  TypeError
+    ( 'Text ""
+        :<>: 'ShowType x
+        :<>: 'Text ", a child of HyperView "
+        :<>: 'ShowType id
+        :<>: 'Text ", not handled by context "
+        :<>: 'ShowType ctx
+        :$$: ('Text " Require = " ':<>: 'ShowType cs)
+        -- ':$$: 'ShowType x
+        -- ':$$: 'ShowType cs
+    )
+
+
+type NotInPage x total =
+  TypeError
+    ( 'Text ""
+        :<>: 'ShowType x
+        :<>: 'Text " not included in: "
+        :$$: 'Text "  Page es "
+          :<>: ShowType total
+        :$$: 'Text "try expanding the page views to:"
+        :$$: 'Text "  Page es "
+          :<>: ShowType (x : total)
+          -- :$$: 'Text " " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Action id) :<>: 'Text ""
+          -- :$$: 'Text "    page :: (Hyperbole :> es) => Page es '[" :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
+    )
+
+
+type HyperViewHandled id ctx =
+  ( -- the id must be found in the children of the context
+    ElemOr id (Require ctx) (NotHandled id ctx (Require ctx))
+  , -- Make sure the descendents of id are in the context for the root page
+    CheckDescendents id ctx
+  )
+
+
+-- TODO: Report which view requires the missing one
+type family CheckDescendents id ctx :: Constraint where
+  CheckDescendents id (Root total) =
+    ( AllInPage (ValidDescendents id) total
+    )
+  CheckDescendents id ctx = ()
+
+
+type family AllInPage ids total :: Constraint where
+  AllInPage '[] _ = ()
+  AllInPage (x ': xs) total =
+    (ElemOr x total (NotInPage x total), AllInPage xs total)
+
+
+-- TODO: if I'm going to limit it, it's going to happen here
+-- AND all their children have to be there
+-- , All (Elem (Require ctx)) (Require id)
+hyper
+  :: forall id ctx
+   . (HyperViewHandled id ctx, ViewId id)
+  => id
+  -> View id ()
+  -> View ctx ()
+hyper = hyperUnsafe
+
+
+hyperUnsafe :: (ViewId id) => id -> View id () -> View ctx ()
+hyperUnsafe vid vw = do
+  el (att "id" (toViewId vid) . flexCol) $
+    addContext vid vw
+
+
+-- | Internal
+dataTarget :: (ViewId a) => a -> Mod
+dataTarget = att "data-target" . toViewId
+
+
+{- | Trigger actions for another view. They will update the view specified
+
+> otherView :: View OtherView ()
+> otherView = do
+>   el_ "This is not a message view"
+>   button OtherAction id "Do Something"
+>
+>   target (Message 2) $ do
+>     el_ "Now we can trigger a MessageAction which will update our Message HyperView, not this one"
+>     button ClearMessage id "Clear Message #2"
+-}
+target :: (HyperViewHandled id ctx) => id -> View id () -> View ctx ()
+target = addContext

--- a/src/Web/Hyperbole/Forms.hs
+++ b/src/Web/Hyperbole/Forms.hs
@@ -49,7 +49,6 @@ import Web.FormUrlEncoded qualified as FE
 import Web.HttpApiData (FromHttpApiData (..))
 import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.HyperView
-import Web.Hyperbole.View.Target (dataTarget)
 import Web.View hiding (form, input, label)
 import Web.View.Style (addClass, cls, prop)
 
@@ -296,7 +295,7 @@ userForm v = do
     'submit' (border 1) \"Submit\"
 @
 -}
-form :: (Form form val, HyperView id) => Action id -> Mod -> View (FormFields id) () -> View id ()
+form :: (Form form val, ViewId id, ViewAction (Action id)) => Action id -> Mod -> View (FormFields id) () -> View id ()
 form a md cnt = do
   vid <- context
   tag "form" (onSubmit a . dataTarget vid . md . flexCol . marginEnd0) $ do

--- a/src/Web/Hyperbole/Handler.hs
+++ b/src/Web/Hyperbole/Handler.hs
@@ -10,12 +10,7 @@ import Effectful.Reader.Dynamic
 import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.Effect.Server
 import Web.Hyperbole.HyperView
-import Web.Hyperbole.View.Target (hyperUnsafe)
 import Web.View
-
-
-class Handle view es where
-  handle :: (Hyperbole :> es) => Action view -> Eff (Reader view : es) (View view ())
 
 
 class HasViewId m view where
@@ -45,7 +40,7 @@ instance RunHandlers '[] es where
   runHandlers = pure ()
 
 
-instance (HyperView view, Handle view es, RunHandlers views es) => RunHandlers (view : views) es where
+instance (HyperView view es, RunHandlers views es) => RunHandlers (view : views) es where
   runHandlers = do
     runHandler @view (handle @view)
     runHandlers @views
@@ -64,7 +59,7 @@ instance (HyperView view, Handle view es, RunHandlers views es) => RunHandlers (
 
 runHandler
   :: forall id es
-   . (HyperView id, Hyperbole :> es)
+   . (HyperView id es, Hyperbole :> es)
   => (Action id -> Eff (Reader id : es) (View id ()))
   -> Eff es ()
 runHandler run = do

--- a/src/Web/Hyperbole/Handler/TypeList.hs
+++ b/src/Web/Hyperbole/Handler/TypeList.hs
@@ -4,23 +4,10 @@ module Web.Hyperbole.Handler.TypeList where
 
 import Data.Kind (Constraint, Type)
 import GHC.TypeLits hiding (Mod)
-import Web.Hyperbole.HyperView
 
 
 -- type family AllDescendents (xs :: [Type]) :: [Type] where
 --   AllDescendents xs = xs <++> RemoveAll xs (NextDescendents '[] xs)
-
-type family ValidDescendents x :: [Type] where
-  ValidDescendents x = x : NextDescendents '[] '[x]
-
-
-type family NextDescendents (ex :: [Type]) (xs :: [Type]) where
-  NextDescendents _ '[] = '[]
-  NextDescendents ex (x ': xs) =
-    RemoveAll (x : ex) (Require x)
-      <++> NextDescendents ((x : ex) <++> Require x) (RemoveAll (x : ex) (Require x))
-      <++> NextDescendents (x : ex) (RemoveAll (x : ex) xs)
-
 
 -- concat lists
 type family (<++>) xs ys where
@@ -39,72 +26,6 @@ type family RemoveAll xs ys where
   RemoveAll '[] ys = ys
   RemoveAll xs '[] = '[]
   RemoveAll (x ': xs) ys = RemoveAll xs (Remove x ys)
-
-
-type NotHandled id ctx (views :: [Type]) =
-  TypeError
-    ( 'Text "HyperView "
-        :<>: 'ShowType id
-        :<>: 'Text " not found in (Require "
-        :<>: 'ShowType ctx
-        :<>: 'Text ")"
-        :$$: 'Text "  " :<>: 'ShowType views
-        :$$: 'Text "Try adding it to the HyperView instance:"
-        :$$: 'Text "  instance HyperView " :<>: 'ShowType ctx :<>: 'Text " where"
-        :$$: 'Text "    type Action " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Action id) :<>: 'Text ""
-        :$$: 'Text "    type Require " :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
-    )
-
-
-type NotDesc id ctx x cs =
-  TypeError
-    ( 'Text ""
-        :<>: 'ShowType x
-        :<>: 'Text ", a child of HyperView "
-        :<>: 'ShowType id
-        :<>: 'Text ", not handled by context "
-        :<>: 'ShowType ctx
-        :$$: ('Text " Require = " ':<>: 'ShowType cs)
-        -- ':$$: 'ShowType x
-        -- ':$$: 'ShowType cs
-    )
-
-
-type NotInPage x total =
-  TypeError
-    ( 'Text ""
-        :<>: 'ShowType x
-        :<>: 'Text " not included in: "
-        :$$: 'Text "  Page es " :<>: ShowType total
-        :$$: 'Text "try expanding the page views to:"
-        :$$: 'Text "  Page es " :<>: ShowType (x : total)
-        -- :$$: 'Text " " :<>: 'ShowType ctx :<>: 'Text " = " :<>: ShowType (Action id) :<>: 'Text ""
-        -- :$$: 'Text "    page :: (Hyperbole :> es) => Page es '[" :<>: 'ShowType ctx :<>: 'Text " = [" :<>: ShowType id :<>: 'Text ", ...]"
-    )
-
-
-type HyperViewHandled id ctx =
-  ( HyperView id
-  , HyperView ctx
-  , -- the id must be found in the children of the context
-    ElemOr id (Require ctx) (NotHandled id ctx (Require ctx))
-  , -- Make sure the descendents of id are in the context for the root page
-    CheckDescendents id ctx
-  )
-
-
--- TODO: Report which view requires the missing one
-type family CheckDescendents id ctx :: Constraint where
-  CheckDescendents id (Root total) =
-    ( AllInPage (ValidDescendents id) total
-    )
-  CheckDescendents id ctx = ()
-
-
-type family AllInPage ids total :: Constraint where
-  AllInPage '[] _ = ()
-  AllInPage (x ': xs) total =
-    (ElemOr x total (NotInPage x total), AllInPage xs total)
 
 
 -- Type family to check if an element is in a type-level list

--- a/src/Web/Hyperbole/HyperView.hs
+++ b/src/Web/Hyperbole/HyperView.hs
@@ -3,32 +3,8 @@
 
 module Web.Hyperbole.HyperView where
 
-import Data.Kind (Type)
 import Data.Text (Text, pack, unpack)
 import Text.Read (readMaybe)
-
-
-{- | HyperViews are interactive subsections of a 'Page'
-
-Create an instance with a unique view id type and a sum type describing the actions the HyperView supports. The View Id can contain context (a database id, for example)
-
-@
-data Message = Message Int
-  deriving (Generic, 'Param')
-
-data MessageAction
-  = Louder Text
-  | ClearMessage
-  deriving (Generic, 'Param')
-
-instance HyperView Message where
-  type Action Message = MessageAction
-@
--}
-class (ViewId id, ViewAction (Action id)) => HyperView id where
-  data Action id :: Type
-  type Require id :: [Type]
-  type Require id = '[]
 
 
 class ViewAction a where
@@ -56,17 +32,6 @@ class ViewId a where
   parseViewId :: Text -> Maybe a
   default parseViewId :: (Read a) => Text -> Maybe a
   parseViewId = readMaybe . unpack
-
-
--- | The top-level view created by 'load'. Carries the views in its type to check that we handled all our views
-data Root (views :: [Type]) = Root
-  deriving (Show, Read, ViewId)
-
-
-instance HyperView (Root views) where
-  data Action (Root views) = RootNone
-    deriving (Show, Read, ViewAction)
-  type Require (Root views) = views
 
 
 type family TupleList a where

--- a/src/Web/Hyperbole/Page.hs
+++ b/src/Web/Hyperbole/Page.hs
@@ -5,7 +5,6 @@ import Effectful
 import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.Effect.Server (Response)
 import Web.Hyperbole.Handler (RunHandlers, runLoad)
-import Web.Hyperbole.HyperView (Root)
 import Web.View (View)
 
 

--- a/src/Web/Hyperbole/View.hs
+++ b/src/Web/Hyperbole/View.hs
@@ -6,8 +6,8 @@ module Web.Hyperbole.View
   , module Web.View
   ) where
 
+import Web.Hyperbole.Effect.Hyperbole (hyper, target)
 import Web.Hyperbole.View.Element
 import Web.Hyperbole.View.Event
-import Web.Hyperbole.View.Target
 import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, label)
 

--- a/src/Web/Hyperbole/View/Element.hs
+++ b/src/Web/Hyperbole/View/Element.hs
@@ -2,10 +2,10 @@ module Web.Hyperbole.View.Element where
 
 import Data.Text (Text, pack)
 import Data.Text qualified as T
-import Web.Hyperbole.HyperView
+import Web.Hyperbole.Effect.Hyperbole (HyperView (..), dataTarget)
+import Web.Hyperbole.HyperView (ViewAction (..), ViewId (..))
 import Web.Hyperbole.Route (Route (..), routeUrl)
 import Web.Hyperbole.View.Event (DelayMs)
-import Web.Hyperbole.View.Target (dataTarget)
 import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, label)
 
 
@@ -13,7 +13,7 @@ import Web.View hiding (Query, Segment, button, cssResetEmbed, form, input, labe
 
 > button SomeAction (border 1) "Click Me"
 -}
-button :: (HyperView id) => Action id -> Mod -> View id () -> View id ()
+button :: (ViewId id, ViewAction (Action id)) => Action id -> Mod -> View id () -> View id ()
 button a f cd = do
   c <- context
   tag "button" (att "data-on-click" (toAction a) . dataTarget c . f) cd
@@ -39,7 +39,7 @@ allContactsView fil = do
 @
 -}
 dropdown
-  :: (HyperView id)
+  :: (ViewId id, ViewAction (Action id))
   => (opt -> Action id)
   -> (opt -> Bool) -- check if selec
   -> Mod
@@ -53,7 +53,7 @@ dropdown act isSel f options = do
 
 -- | An option for a 'dropdown'. First argument is passed to (opt -> Action id) in the 'dropdown', and to the selected predicate
 option
-  :: (HyperView id, Eq opt)
+  :: (ViewId id, ViewAction (Action id), Eq opt)
   => opt
   -> View (Option opt id (Action id)) ()
   -> View (Option opt id (Action id)) ()
@@ -75,7 +75,7 @@ data Option opt id action = Option
 
 
 -- | A live search field
-search :: (HyperView id) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
+search :: (ViewId id, ViewAction (Action id)) => (Text -> Action id) -> DelayMs -> Mod -> View id ()
 search onInput delay f = do
   c <- context
   tag "input" (att "data-on-input" (toActionInput onInput) . att "data-delay" (pack $ show delay) . dataTarget c . f) none

--- a/src/Web/Hyperbole/View/Event.hs
+++ b/src/Web/Hyperbole/View/Event.hs
@@ -1,8 +1,8 @@
 module Web.Hyperbole.View.Event where
 
 import Data.Text (pack)
+import Web.Hyperbole.Effect.Hyperbole
 import Web.Hyperbole.HyperView
-import Web.Hyperbole.View.Target
 import Web.View (View, att, context, el, flexCol, hide, parent)
 
 
@@ -19,7 +19,7 @@ pollMessageView m = do
     'el_' ('text' m)
 @
 -}
-onLoad :: (HyperView id) => Action id -> DelayMs -> View id () -> View id ()
+onLoad :: (ViewId id, ViewAction (Action id)) => Action id -> DelayMs -> View id () -> View id ()
 onLoad a delay initContent = do
   c <- context
   el (att "data-on-load" (toAction a) . att "data-delay" (pack $ show delay) . dataTarget c) initContent

--- a/src/Web/Hyperbole/View/Target.hs
+++ b/src/Web/Hyperbole/View/Target.hs
@@ -1,8 +1,6 @@
 module Web.Hyperbole.View.Target where
 
-import Web.Hyperbole.Handler.TypeList (HyperViewHandled)
-import Web.Hyperbole.HyperView
-import Web.View (Mod, View, addContext, att, el, flexCol)
+import Web.Hyperbole.Handler.TypeList ()
 
 
 {- | Embed HyperViews into the page, or nest them into other views
@@ -34,40 +32,3 @@ otherView = do
   button (Louder \"Hi\") id \"Louder\"
 @
 -}
-
--- TODO: if I'm going to limit it, it's going to happen here
--- AND all their children have to be there
--- , All (Elem (Require ctx)) (Require id)
-hyper
-  :: forall id ctx
-   . (HyperViewHandled id ctx)
-  => id
-  -> View id ()
-  -> View ctx ()
-hyper = hyperUnsafe
-
-
-hyperUnsafe :: (ViewId id) => id -> View id () -> View ctx ()
-hyperUnsafe vid vw = do
-  el (att "id" (toViewId vid) . flexCol) $
-    addContext vid vw
-
-
--- | Internal
-dataTarget :: (ViewId a) => a -> Mod
-dataTarget = att "data-target" . toViewId
-
-
-{- | Trigger actions for another view. They will update the view specified
-
-> otherView :: View OtherView ()
-> otherView = do
->   el_ "This is not a message view"
->   button OtherAction id "Do Something"
->
->   target (Message 2) $ do
->     el_ "Now we can trigger a MessageAction which will update our Message HyperView, not this one"
->     button ClearMessage id "Clear Message #2"
--}
-target :: (HyperView id) => id -> View id () -> View a ()
-target = addContext


### PR DESCRIPTION
As @cgeorgii figured out in #47, we can unify the `Handler` and `HyperView` typeclasses without issues passing around the `es` if we make function signatures that mention an associated type of HyperView. 

```
class (ViewId id, ViewAction (Action id)) => HyperView id es where
  type Action id :: Type
  type Require id :: [Type]
  type Require id = '[]


  handle :: (Hyperbole :> es) => Action id -> Eff (Reader id : es) (View id ())
```

In the new version, we don't need a `HyperView id es` constraint, because `Action id` already requires that `Action id` and `id` match. This is good, because there's no `es` on the right hand side, which requires ambiguous types and forcing the user to specify types everywhere. 
  
```
button :: (ViewId id, ViewAction (Action id)) => Action id -> Mod -> View id () -> View id ()
```