### PR TITLE
Rename context type variable to match documentation

### DIFF
--- a/example/Example/Intro/ViewFunctions.hs
+++ b/example/Example/Intro/ViewFunctions.hs
@@ -35,6 +35,6 @@ goodbyeButton :: View Message ()
 goodbyeButton = do
   button (SetMessage "Goodbye") (border 1) "Say Goodbye"
 
-header :: Text -> View c ()
+header :: Text -> View context ()
 header txt = do
   el bold (text txt)


### PR DESCRIPTION
The documentation mentions `context` but the code calls it `c`. I think making them explicitly the same might help newcomers.

> We showed earlier that we can write a View Function with a generic **context** that we can reuse in any view. A function like this might help us reuse styles:


```
header :: Text -> View c () -- Confusing
header txt = do
  el bold (text txt)

header :: Text -> View context () -- Matches the text
header txt = do
  el bold (text txt)
```