### PR TITLE
add query params example

### DIFF
--- a/example/Example/AppRoute.hs
+++ b/example/Example/AppRoute.hs
@@ -19,6 +19,7 @@ data AppRoute
   | Filter
   | Sessions
   | Requests
+  | QueryParams
   | Redirects
   | RedirectNow
   | LazyLoading

--- a/example/Example/Page/QueryParams.hs
+++ b/example/Example/Page/QueryParams.hs
@@ -1,0 +1,52 @@
+module Example.Page.QueryParams where
+
+import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
+import Data.String.Conversions (cs)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.Encoding (decodeUtf8)
+import Effectful
+import Example.AppRoute qualified as Route
+import Example.View.Layout (exampleLayout)
+import Web.Hyperbole
+import Web.Hyperbole.Effect.Server (Host (..), Request (..))
+
+data Dolphin = Dolphin
+  { name :: Text,
+    age :: Int
+  }
+  deriving (Generic, Read, FromQueryData, Show)
+
+readDolphin :: [(Text, Maybe Text)] -> Maybe Dolphin
+readDolphin query = case ((read @Int . T.unpack) <$> l "age", l "name") of
+  (Just age', Just name') -> Just $ Dolphin name' age'
+  _ -> Nothing
+  where
+    m = Map.fromList $ mapMaybe normalise query
+    l k = Map.lookup k m
+
+normalise :: (a, Maybe b) -> Maybe (a, b)
+normalise (a, Just b) = Just (a, b)
+normalise _ = Nothing
+
+page :: (Hyperbole :> es) => Eff es (Page '[])
+page = do
+  r <- request
+  pure $ exampleLayout Route.QueryParams $ do
+    col (gap 10 . pad 10) $ do
+      el_ $ do
+        case readDolphin r.query of
+          Just d -> do
+            col (gap 10) $ do
+              el_ $ text "successfully constructed record from query params:"
+              el_ $ text $ cs $ show d
+          Nothing -> col (gap 10) $ do
+            el_ $ text $ cs ("failure: check query params" ++ show r.query)
+            let Host host = r.host
+            let queryArgs = T.intercalate "&" $ map (\(x, y) -> x <> "=" <> y) [("age", "12"), ("name", "bubu")]
+            let ps = T.intercalate "/" $ "http://" : decodeUtf8 host : (r.path ++ ["?" <> queryArgs])
+            let theUrl = url ps
+            row (gap 10) $ do
+              el_ $ text "click link to send query params:"
+              el_ $ link theUrl id (text $ cs $ show theUrl)

--- a/example/Example/Page/Requests.hs
+++ b/example/Example/Page/Requests.hs
@@ -13,6 +13,9 @@ page = do
   pure $ exampleLayout Route.Requests $ do
     col (gap 10 . pad 10) $ do
       el_ $ do
+        text "Method: "
+        text $ cs $ show r.method
+      el_ $ do
         text "Host: "
         text $ cs $ show r.host
       el_ $ do

--- a/example/Example/View/Layout.hs
+++ b/example/Example/View/Layout.hs
@@ -39,6 +39,7 @@ exampleLayout rt pageView = do
     Concurrent -> "Example/Page/Concurrent.hs"
     Redirects -> "Example/Page/Redirects.hs"
     Requests -> "Example/Page/Requests.hs"
+    QueryParams -> "Example/Page/QueryParams.hs"
     Filter -> "Example/Page/Filter.hs"
     LiveSearch -> "Example/Page/LiveSearch.hs"
     Errors -> "Example/Page/Errors.hs"
@@ -65,6 +66,7 @@ exampleMenu current = do
   example Transitions
   example Sessions
   example Requests
+  example QueryParams
   example Redirects
   example RedirectNow
   example LazyLoading

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -35,6 +35,7 @@ import Example.Page.FormValidation qualified as FormValidation
 import Example.Page.LazyLoading qualified as LazyLoading
 import Example.Page.Redirects qualified as Redirects
 import Example.Page.Requests qualified as Requests
+import Example.Page.QueryParams qualified as QueryParams
 import Example.Page.Search qualified as Search
 import Example.Page.Sessions qualified as Sessions
 import Example.Page.Simple qualified as Simple
@@ -96,6 +97,7 @@ app users count = do
     redirect (routeUrl $ Hello Redirected)
   router Redirects = runPage Redirects.page
   router Requests = runPage Requests.page
+  router QueryParams = runPage QueryParams.page
   router Sessions = runPage Sessions.page
   router Simple = runPage Simple.page
   router Transitions = runPage Transitions.page

--- a/example/hyperbole-examples.cabal
+++ b/example/hyperbole-examples.cabal
@@ -114,6 +114,7 @@ executable examples
       Example.Page.FormSimple
       Example.Page.FormValidation
       Example.Page.LazyLoading
+      Example.Page.QueryParams
       Example.Page.Redirects
       Example.Page.Requests
       Example.Page.Search


### PR DESCRIPTION
Basic query params example; should I be able to read it directly to the record?
I've tried to use [formParse](https://github.com/seanhess/hyperbole/blob/f61bf9d420a95f9937623d5ce1815f9694c7c438/test/Test/FormSpec.hs#L35) to no avail.

The simplest user interface I can conceive is:
- data record (specifying which field is required and which is Maybe)
- specifying whether it can originate from POST or GET args
- command that decodes it from the request
(so, what I've in mind is a unified interface for both POST and GET)