### PR TITLE
Adds cachix to CI and flake

### DIFF
--- a/.github/workflows/haskell.yaml
+++ b/.github/workflows/haskell.yaml
@@ -2,9 +2,7 @@ name: Haskell CI
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -22,24 +20,41 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@v4
+      
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          
+      - uses: cachix/cachix-action@v14
+        with:
+          name: hyperbole
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Check packages
         run: |
           nix flake check
 
-      # Docker steps start here
+  docker:
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          
+      - uses: cachix/cachix-action@v14
+        with:
+          name: hyperbole
+
       - name: Build container
         run: nix build .#docker
 
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,7 +62,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load and push image
-        if: github.event_name != 'pull_request'
         run: |
           # Load the image
           docker load < result

--- a/README.md
+++ b/README.md
@@ -82,9 +82,17 @@ The example directory contains an app demonstrating various features. See it in 
   <img alt="Hyperbole Examples" src="example/static/examples.png"/>
 </a>
 
-### Try Example Project with Nix
+### Try Example Project Locally
 
-If you want to get a feel for hyperbole without cloning the project run `nix run github:seanhess/hyperbole` to run the example webserver locally
+These will run the examples webserver
+
+#### With Nix
+
+`nix run github:seanhess/hyperbole`
+
+#### With Docker
+
+`docker run -it -p 3000:3000 ghcr.io/seanhess/hyperbole:latest`
 
 Learn More
 ----------
@@ -162,6 +170,8 @@ You can import this flake's overlay to add `hyperbole` to all package sets and o
     );
 }
 ```
+
+Note: You can always run `cachix use hyperbole` to use the GitHub CI populated cache if you didn't allow adding 'extra-substituters' when first using this flake.
 
 ### Manual dependency installation
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,15 @@
 {
   description = "hyperbole overlay, development and hyperbole-examples";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://hyperbole.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "hyperbole.cachix.org-1:9Pl9dJXuJrAxGkrG8WNQ/hlO9rKt9b5IPksG7y78UGQ="
+    ];
+  };
+
   inputs = {
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
@@ -207,8 +216,10 @@
           map (version: {
             name = "ghc${version}-check-${examplesName}";
             value = pkgs.runCommand "ghc${version}-check-example" {
-              buildInputs = [ (exe version) ];
-            } "type examples; type docgen; touch $out";
+              buildInputs = [
+                (exe version)
+              ] ++ self.devShells.${system}."ghc${version}-shell".buildInputs;
+            } "type examples; type docgen; CABAL_CONFIG=/dev/null cabal --dry-run repl; touch $out";
           }) ghcVersions
         );
 
@@ -229,7 +240,7 @@
 
         packages =
           {
-            default = self.packages.${system}."ghc982-${examplesName}";
+            default = self.packages.${system}."ghc982-${packageName}";
             docker = self.packages.${system}."ghc982-docker";
           }
           // builtins.listToAttrs (
@@ -241,6 +252,10 @@
               {
                 name = "ghc${version}-docker";
                 value = docker version;
+              }
+              {
+                name = "ghc${version}-${packageName}";
+                value = ghcPkgs."ghc${version}".${packageName};
               }
             ]) ghcVersions
           );


### PR DESCRIPTION
There is no rush on this PR, you can look at this after your vacation.

Updates
  - `nix flake check` also checks `nix develop` can run `cabal --dry-run repl`
  - GitHub CI uploads the build dependencies to cachix
  - reduces the CI time to under 4min
  - adds cachix to flake so users can benefit from CI builds
  - runs CI on all branches and all pull requests
    - Only pushes will update the cache since pull requests do not get access to secrets
  - only updates docker image from main branch push

Requires
  - need to add CACHIX_AUTH_TOKEN as a repository secret
    - It can be found in: settings -> secrets and variables -> Actions -> New repository secret
    - you need to create a cachix account before I can add you (they don't have an invite system)
    - To create the auth token: Settings -> Auth Tokens -> Generate 
      - Make sure it is (Write + Read), and (Never) expires

You can merge this without creating a cachix account and setting `CACHIX_AUTH_TOKEN` since my fork already populated the cache.