### PR TITLE
Forms Classes Redesign

### DIFF
--- a/example/Example/Page/Contacts.hs
+++ b/example/Example/Page/Contacts.hs
@@ -87,7 +87,7 @@ allContactsView fil us = col (gap 20) $ do
   el bold "Add Contact"
 
   row (pad 10 . gap 10 . border 1) $ do
-    contactForm AddUser genForm
+    contactForm AddUser genFields
  where
   filterUsers Nothing _ = True
   filterUsers (Just Active) u = u.isActive

--- a/src/Web/Hyperbole.hs
+++ b/src/Web/Hyperbole.hs
@@ -120,11 +120,14 @@ module Web.Hyperbole
     -- * Type-Safe Forms
 
     -- | Painless forms with type-checked field names, and support for validation. See [Example.Forms](https://docs.hyperbole.live/formsimple)
+  , FromForm (..)
+  , FromFormF (..)
   , formData
-  , Form (..)
-  , formFields
-  , formFieldsWith
-  , FormField
+  , GenFields (..)
+  , fieldNames
+  , FieldName (..)
+  , FormFields
+  -- , FormField (..)
   , Field
   , Identity
 
@@ -140,10 +143,9 @@ module Web.Hyperbole
 
     -- ** Validation
   , Validated (..)
+  , isInvalid
   , validate
-  , fieldValid
   , invalidText
-  , anyInvalid
 
     -- * Query Param Encoding
   , ToQuery (..)

--- a/src/Web/Hyperbole/View/Forms.hs
+++ b/src/Web/Hyperbole/View/Forms.hs
@@ -1,12 +1,18 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Web.Hyperbole.View.Forms
-  ( FormFields (..)
+  ( FromForm (..)
+  , FromFormF (..)
+  , formParam
+  , formLookup
+  , GenFields (..)
+  , fieldNames
+  , FieldName (..)
+  , FormFields (..)
+  , Field
   , InputType (..)
-  , FieldName
-  , Invalid
   , Input (..)
   , field
   , label
@@ -16,18 +22,10 @@ module Web.Hyperbole.View.Forms
   , placeholder
   , submit
   , formData
-  , Form (..)
-  , formParseParam
-  , formLookupParam
-  , formFields
-  , formFieldsWith
-  , Field
   , defaultFormOptions
   , FormOptions (..)
   , Validated (..)
-  , FormField (..)
-  , fieldValid
-  , anyInvalid
+  , isInvalid
   , invalidText
   , validate
   , Identity
@@ -35,8 +33,9 @@ module Web.Hyperbole.View.Forms
     -- * Re-exports
   , FromParam
   , Generic
-  , GenFields (..)
+  , GFieldsGen (..)
   , GenField (..)
+  , Form (..)
   )
 where
 
@@ -44,12 +43,12 @@ import Data.Function ((&))
 import Data.Functor.Identity (Identity (..))
 import Data.Kind (Type)
 import Data.Maybe (fromMaybe)
+import Data.String (IsString (..))
 import Data.Text (Text, pack)
-import Debug.Trace
 import Effectful
 import GHC.Generics
 import Text.Casing (kebab)
-import Web.FormUrlEncoded (FormOptions (..), defaultFormOptions, parseUnique)
+import Web.FormUrlEncoded (Form (..), FormOptions (..), defaultFormOptions, parseUnique)
 import Web.FormUrlEncoded qualified as FE
 import Web.Hyperbole.Data.QueryData (FromParam (..), Param (..), ParamValue (..))
 import Web.Hyperbole.Effect.Hyperbole
@@ -61,29 +60,150 @@ import Web.View hiding (form, input, label)
 import Web.View.Style (addClass, cls, prop)
 
 
--- | The only time we can use Fields is inside a form
+------------------------------------------------------------------------------
+-- FORM PARSING
+------------------------------------------------------------------------------
+
+-- | Equivalent to Web.FormUrlEncoded.FromForm, but uses 'FromParam' instead of 'FromHttpApiData'
+class FromForm (form :: Type) where
+  fromForm :: FE.Form -> Either Text form
+  default fromForm :: (Generic form, GFormParse (Rep form)) => FE.Form -> Either Text form
+  fromForm f = to <$> gFormParse f
+
+
+{- | A Higher-Kinded type that can be parsed from a 'Web.FormUrlEncoded.Form'
+
+From [Example.Page.FormSimple](https://docs.hyperbole.live/formsimple)
+
+@
+#EMBED Example/Page/FormSimple.hs data ContactForm
+#EMBED Example/Page/FormSimple.hs instance Form ContactForm
+@
+-}
+class FromFormF (f :: (Type -> Type) -> Type) where
+  fromFormF :: FE.Form -> Either Text (f Identity)
+  default fromFormF :: (Generic (f Identity), GFormParse (Rep (f Identity))) => FE.Form -> Either Text (f Identity)
+  fromFormF f = to <$> gFormParse f
+
+
+-- Any FromFormF can be parsed using fromForm @(form Identity)
+instance (FromFormF form) => FromForm (form Identity) where
+  fromForm = fromFormF
+
+
+-- | Parse a full type from the form data
+formData :: forall form es. (FromForm form, Hyperbole :> es) => Eff es form
+formData = do
+  f <- formBody
+  let ef = fromForm @form f :: Either Text form
+  either parseError pure ef
+
+
+-- | Parse a single param from a Form
+formParam :: (FromParam a) => Param -> FE.Form -> Either Text a
+formParam (Param key) frm = do
+  t <- FE.parseUnique @Text key frm
+  parseParam (ParamValue t)
+
+
+-- | Lookup a single param from a Form
+formLookup :: (FromParam a) => Param -> FE.Form -> Either Text (Maybe a)
+formLookup (Param key) frm = do
+  mt <- FE.parseMaybe @Text key frm
+  maybe (pure Nothing) (parseParam . ParamValue) mt
+
+
+------------------------------------------------------------------------------
+-- GEN FIELDS: Generate a type from selector names
+------------------------------------------------------------------------------
+
+class GenFields f (form :: (Type -> Type) -> Type) where
+  -- {- | Generate a Higher Kinded Type (form f)
+  --
+  -- > #EMBED Example/Page/FormValidation.hs data UserForm
+  -- >
+  -- > #EMBED Example/Page/FormValidation.hs page
+  -- -}
+  genFields :: form f
+  default genFields :: (Generic (form f), GFieldsGen (Rep (form f))) => form f
+  genFields = to gFieldsGen
+
+
+-- {- | Generate FieldNames for a form. See [Example.Page.FormSimple](https://docs.hyperbole.live/formsimple)
+--
+-- > #EMBED Example/Page/FormSimple.hs data ContactForm'
+-- >
+-- > #EMBED Example/Page/FormSimple.hs formView'
+-- -}
+fieldNames :: forall form. (GenFields FieldName form) => form FieldName
+fieldNames = genFields
+
+
+-- Given a selector, generate the type
+class GenField a where
+  genField :: String -> a
+
+
+instance GenField (FieldName a) where
+  genField s = FieldName $ pack s
+
+
+instance GenField (Validated a) where
+  genField = const NotInvalid
+
+
+instance GenField (Maybe a) where
+  genField _ = Nothing
+
+
+------------------------------------------------------------------------------
+-- FORM VIEWS
+------------------------------------------------------------------------------
+
+-- | Context that allows form fields
 data FormFields id = FormFields id
 
 
-data FormField v a = FormField
-  { fieldName :: FieldName a
-  , validated :: v a
-  }
-  deriving (Show)
+{- | Type-safe \<form\>. Calls (Action id) on submit
+
+@
+#EMBED Example/Page/FormSimple.hs formView
+@
+-}
+form :: (ViewAction (Action id)) => Action id -> Mod id -> View (FormFields id) () -> View id ()
+form a md cnt = do
+  vid <- context
+  tag "form" (onSubmit a . md . flexCol . marginEnd0) $ do
+    addContext (FormFields vid) cnt
+ where
+  -- not sure why chrome is adding margin-block-end: 16 to forms? Add to web-view?
+  marginEnd0 =
+    addClass $
+      cls "mg-end-0"
+        & prop @PxRem "margin-block-end" 0
 
 
--- instance Show (v a) => Show (FormField v) where
---   show f = "Form Field"
+-- | Button that submits the 'form'
+submit :: Mod (FormFields id) -> View (FormFields id) () -> View (FormFields id) ()
+submit f = tag "button" (att "type" "submit" . f)
 
--- instance (ViewId id) => ViewId (FormFields id v fs) where
---   parseViewId t = do
---     i <- parseViewId t
---     pure $ FormFields i lbls mempty
---   toViewId (FormFields i _ _) = toViewId i
---
---
--- instance (HyperView id, ViewId id) => HyperView (FormFields id v fs) where
---   type Action (FormFields id v fs) = Action id
+
+-- | Form FieldName. This is embeded as the name attribute, and refers to the key need to parse the form when submitted. See 'fieldNames'
+newtype FieldName a = FieldName Text
+  deriving newtype (Show, IsString)
+
+
+-- | Display a 'FormField'. See 'form' and 'Form'
+field
+  :: forall (id :: Type) (a :: Type)
+   . FieldName a
+  -> Mod (FormFields id)
+  -> View (Input id a) ()
+  -> View (FormFields id) ()
+field fn f inputs = do
+  tag "label" (f . flexCol) $ do
+    addContext (Input fn) inputs
+
 
 -- | Choose one for 'input's to give the browser autocomplete hints
 data InputType
@@ -104,6 +224,48 @@ data InputType
   | Search
   deriving (Show)
 
+
+data Input (id :: Type) (a :: Type) = Input
+  { inputName :: FieldName a
+  }
+
+
+-- | label for a 'field'
+label :: Text -> View (Input id a) ()
+label = text
+
+
+-- | input for a 'field'
+input :: InputType -> Mod (Input id a) -> View (Input id a) ()
+input ft f = do
+  Input (FieldName nm) <- context
+  tag "input" (f . name nm . att "type" (inpType ft) . att "autocomplete" (auto ft)) none
+ where
+  inpType NewPassword = "password"
+  inpType CurrentPassword = "password"
+  inpType Number = "number"
+  inpType Email = "email"
+  inpType Search = "search"
+  inpType _ = "text"
+
+  auto :: InputType -> Text
+  auto = pack . kebab . show
+
+
+placeholder :: Text -> Mod id
+placeholder = att "placeholder"
+
+
+-- | textarea for a 'field'
+textarea :: Mod (Input id a) -> Maybe Text -> View (Input id a) ()
+textarea f mDefaultText = do
+  Input (FieldName nm) <- context
+  tag "textarea" (f . name nm) (text $ fromMaybe "" mDefaultText)
+
+
+------------------------------------------------------------------------------
+-- VALIDATION
+------------------------------------------------------------------------------
 
 {- | Validation results for a 'Form'. See 'validate'
 
@@ -132,30 +294,40 @@ instance Monoid (Validated a) where
   mempty = NotInvalid
 
 
-class ValidationState (v :: Type -> Type) where
-  convert :: v a -> v b
-  isInvalid :: v a -> Bool
+instance (FromParam a, ValidateField a) => FromParam (Validated a) where
+  parseParam inp = do
+    a <- parseParam @a inp
+    pure $ validateField a
 
 
-instance ValidationState Validated where
-  convert :: Validated a -> Validated b
-  convert (Invalid t) = Invalid t
-  convert NotInvalid = NotInvalid
-  convert Valid = Valid
+isInvalid :: Validated a -> Bool
+isInvalid (Invalid _) = True
+isInvalid _ = False
 
 
-  isInvalid :: Validated a -> Bool
-  isInvalid (Invalid _) = True
-  isInvalid _ = False
+class ValidateField a where
+  validateField :: a -> Validated a
 
 
-{- Only shows if 'Validated' is 'Invalid'. See 'formFieldsWith'
+-- class ValidationState (v :: Type -> Type) where
+--   convert :: v a -> v b
+--   isInvalid :: v a -> Bool
+--
+--
+-- instance ValidationState Validated where
+--   convert :: Validated a -> Validated b
+--   convert (Invalid t) = Invalid t
+--   convert NotInvalid = NotInvalid
+--   convert Valid = Valid
+--
+--
+
+{- Only shows if 'Validated' is 'Invalid'. See 'formFieldsWith'formform
 @
 @
 -}
-invalidText :: forall a id. View (Input id Validated a) ()
-invalidText = do
-  Input _ v <- context
+invalidText :: forall a id. Validated a -> View (Input id a) ()
+invalidText v = do
   case v of
     Invalid t -> text t
     _ -> none
@@ -172,105 +344,6 @@ validate True t = Invalid t -- Validation [(inputName @a, Invalid t)]
 validate False _ = NotInvalid -- Validation [(inputName @a, NotInvalid)]
 
 
--- validateWith :: forall a fs v. (FormField a, Elem a fs, ValidationState v) => v a -> Validation' v fs
--- validateWith v = Validation [(inputName @a, convert v)]
-
--- eh... not sure how to do this...
-anyInvalid :: forall form val. (Form form val, ValidationState val) => form val -> Bool
-anyInvalid f = any isInvalid (collectValids f :: [val ()])
-
-
--- any (isInvalid . snd) vs
-
--- | Returns the 'Validated' for the 'field'. See 'formFieldsWith'
-fieldValid :: View (Input id v a) (v a)
-fieldValid = do
-  Input _ v <- context
-  pure v
-
-
-data FieldName a = FieldName Text
-  deriving (Show)
-
-
-data Invalid a
-
-
-data Input (id :: Type) (valid :: Type -> Type) (a :: Type) = Input
-  { inputName :: FieldName a
-  , valid :: valid a
-  }
-
-
--- | Display a 'FormField'. See 'form' and 'Form'
-field
-  :: forall (id :: Type) (v :: Type -> Type) (a :: Type)
-   . FormField v a
-  -> (v a -> Mod (FormFields id))
-  -> View (Input id v a) ()
-  -> View (FormFields id) ()
-field fld md cnt = do
-  tag "label" (md fld.validated . flexCol) $ do
-    addContext (Input fld.fieldName fld.validated) cnt
-
-
--- | label for a 'field'
-label :: Text -> View (Input id v a) ()
-label = text
-
-
--- | input for a 'field'
-input :: InputType -> Mod (Input id v a) -> View (Input id v a) ()
-input ft f = do
-  Input (FieldName nm) _ <- context
-  tag "input" (f . name nm . att "type" (inpType ft) . att "autocomplete" (auto ft)) none
- where
-  inpType NewPassword = "password"
-  inpType CurrentPassword = "password"
-  inpType Number = "number"
-  inpType Email = "email"
-  inpType Search = "search"
-  inpType _ = "text"
-
-  auto :: InputType -> Text
-  auto = pack . kebab . show
-
-
-placeholder :: Text -> Mod id
-placeholder = att "placeholder"
-
-
--- | textarea for a 'field'
-textarea :: Mod (Input id v a) -> Maybe Text -> View (Input id v a) ()
-textarea f mDefaultText = do
-  Input (FieldName nm) _ <- context
-  tag "textarea" (f . name nm) (text $ fromMaybe "" mDefaultText)
-
-
-{- | Type-safe \<form\>. Calls (Action id) on submit
-
-@
-#EMBED Example/Page/FormSimple.hs formView
-@
--}
-form :: (Form form v, ViewAction (Action id)) => Action id -> Mod id -> View (FormFields id) () -> View id ()
-form a md cnt = do
-  vid <- context
-  tag "form" (onSubmit a . md . flexCol . marginEnd0) $ do
-    addContext (FormFields vid) cnt
- where
-  -- not sure why chrome is adding margin-block-end: 16 to forms? Add to web-view?
-  marginEnd0 =
-    addClass $
-      cls "mg-end-0"
-        & prop @PxRem "margin-block-end" 0
-
-
--- | Button that submits the 'form'. Use 'button' to specify actions other than submit
-submit :: Mod (FormFields id) -> View (FormFields id) () -> View (FormFields id) ()
-submit f = tag "button" (att "type" "submit" . f)
-
-
 {- | Field allows a Higher Kinded 'Form' to reuse the same selectors for form parsing, generating html forms, and validation
 
 > Field Identity Text ~ Text
@@ -279,97 +352,21 @@ submit f = tag "button" (att "type" "submit" . f)
 type family Field (context :: Type -> Type) a
 
 
+-- type instance Field (FormField f) a = FormField f a
 type instance Field Identity a = a
 type instance Field FieldName a = FieldName a
-type instance Field (FormField v) a = FormField v a
 type instance Field Validated a = Validated a
 type instance Field Maybe a = Maybe a
 type instance Field (Either String) a = Either String a
 
 
-formData :: forall form val es. (Form form val, Hyperbole :> es) => Eff es (form Identity)
-formData = do
-  f <- formBody
-  traceM $ show f
-  let ef = formParse @form @val f :: Either Text (form Identity)
-  case ef of
-    Left e -> parseError e
-    Right a -> pure a
+------------------------------------------------------------------------------
+-- GENERIC FORM PARSE
+------------------------------------------------------------------------------
 
-
-{- | A Form is a Higher Kinded record listing each 'Field'. `ContactForm` `Identity` behaves like a normal record, while `ContactForm` `Maybe` would be maybe values for each field
-
-From [Example.Page.FormSimple](https://docs.hyperbole.live/formsimple)
-
-@
-#EMBED Example/Page/FormSimple.hs data ContactForm
-#EMBED Example/Page/FormSimple.hs instance Form ContactForm
-@
--}
-class Form form (val :: Type -> Type) | form -> val where
-  formParse :: FE.Form -> Either Text (form Identity)
-  default formParse :: (Generic (form Identity), GFormParse (Rep (form Identity))) => FE.Form -> Either Text (form Identity)
-  formParse f = to <$> gFormParse f
-
-
-  collectValids :: (ValidationState val) => form val -> [val ()]
-  default collectValids :: (Generic (form val), GCollect (Rep (form val)) val) => form val -> [val ()]
-  collectValids f = gCollect (from f)
-
-
-  genForm :: form val
-  default genForm :: (Generic (form val), GenFields (Rep (form val))) => form val
-  genForm = to gGenFields
-
-
-  genFieldsWith :: form val -> form (FormField val)
-  default genFieldsWith
-    :: (Generic (form val), Generic (form (FormField val)), GConvert (Rep (form val)) (Rep (form (FormField val))))
-    => form val
-    -> form (FormField val)
-  genFieldsWith fv = to $ gConvert (from fv)
-
-
-formParseParam :: (FromParam a) => Param -> FE.Form -> Either Text a
-formParseParam (Param key) frm = do
-  t <- FE.parseUnique @Text key frm
-  parseParam (ParamValue t)
-
-
-formLookupParam :: (FromParam a) => Param -> FE.Form -> Either Text (Maybe a)
-formLookupParam (Param key) frm = do
-  mt <- FE.parseMaybe @Text key frm
-  maybe (pure Nothing) (parseParam . ParamValue) mt
-
-
-{- | Generate FormFields for the given instance of 'Form', with no validation information. See [Example.Page.FormSimple](https://docs.hyperbole.live/formsimple)
-
-> #EMBED Example/Page/FormSimple.hs data ContactForm
->
-> #EMBED Example/Page/FormSimple.hs formView
--}
-formFields :: (Form form val) => form (FormField val)
-formFields = genFieldsWith genForm
-
-
-{- | Generate FormFields for the given instance of 'Form' from validation data. See [Example.Page.FormValidation](https://docs.hyperbole.live/formvalidation)
-
-> #EMBED Example/Page/FormValidation.hs data UserForm
-> #EMBED Example/Page/FormValidation.hs instance Form UserForm
->
-> #EMBED Example/Page/FormValidation.hs formView
--}
-formFieldsWith :: (Form form val) => form val -> form (FormField val)
-formFieldsWith = genFieldsWith
-
-
--- | Automatically derive labels from form field names
 class GFormParse f where
   gFormParse :: FE.Form -> Either Text (f p)
 
-
--- instance GForm U1 where
---   gForm = U1
 
 instance (GFormParse f, GFormParse g) => GFormParse (f :*: g) where
   gFormParse f = do
@@ -394,99 +391,69 @@ instance (Selector s, FromParam a) => GFormParse (M1 S s (K1 R a)) where
 
 
 ------------------------------------------------------------------------------
--- GEN FIELDS :: Create the field! -------------------------------------------
+-- GENERIC GENERATE FIELDS
 ------------------------------------------------------------------------------
 
-class GenFields f where
-  gGenFields :: f p
+class GFieldsGen f where
+  gFieldsGen :: f p
 
 
-instance GenFields U1 where
-  gGenFields = U1
+instance GFieldsGen U1 where
+  gFieldsGen = U1
 
 
-instance (GenFields f, GenFields g) => GenFields (f :*: g) where
-  gGenFields = gGenFields :*: gGenFields
+instance (GFieldsGen f, GFieldsGen g) => GFieldsGen (f :*: g) where
+  gFieldsGen = gFieldsGen :*: gFieldsGen
 
 
-instance (Selector s, GenField f a, Field f a ~ f a) => GenFields (M1 S s (K1 R (f a))) where
-  gGenFields =
+-- instance (Selector s, GenField g a, Field f a ~ g a) => GFieldsGen (M1 S s (K1 R (g a))) where
+--   gFieldsGen =
+--     let sel = selName (undefined :: M1 S s (K1 R (f a)) p)
+--      in M1 . K1 $ genField @g @a sel
+
+instance (Selector s, GenField a) => GFieldsGen (M1 S s (K1 R a)) where
+  gFieldsGen =
     let sel = selName (undefined :: M1 S s (K1 R (f a)) p)
-     in M1 . K1 $ genField @f @a sel
+     in M1 . K1 $ genField @a sel
 
 
-instance (GenFields f) => GenFields (M1 D d f) where
-  gGenFields = M1 gGenFields
+instance (GFieldsGen f) => GFieldsGen (M1 D d f) where
+  gFieldsGen = M1 gFieldsGen
 
 
-instance (GenFields f) => GenFields (M1 C c f) where
-  gGenFields = M1 gGenFields
-
-
-------------------------------------------------------------------------------
--- GenField -- Generate a value from the selector name
-------------------------------------------------------------------------------
-
-class GenField f a where
-  genField :: String -> Field f a
-
-
-instance GenField FieldName a where
-  genField s = FieldName $ pack s
-
-
-instance GenField Validated a where
-  genField = const NotInvalid
-
-
-instance GenField (FormField Validated) a where
-  genField s = FormField (FieldName $ pack s) NotInvalid
-
-
-instance GenField (FormField Maybe) a where
-  genField s = FormField (FieldName $ pack s) Nothing
-
-
-instance GenField Maybe a where
-  genField _ = Nothing
+instance (GFieldsGen f) => GFieldsGen (M1 C c f) where
+  gFieldsGen = M1 gFieldsGen
 
 
 ------------------------------------------------------------------------------
 -- GMerge - combine two records with the same structure
 ------------------------------------------------------------------------------
 
--- class ConvertFields a where
---   convertFields :: (FromSelector f g) => a f -> a g
---   default convertFields :: (Generic (a f), Generic (a g), GConvert (Rep (a f)) (Rep (a g))) => a f -> a g
---   convertFields x = to $ gConvert (from x)
+-- class GMerge ra rb rc where
+--   gMerge :: ra p -> rb p -> rc p
+--
+--
+-- instance (GMerge ra0 rb0 rc0, GMerge ra1 rb1 rc1) => GMerge (ra0 :*: ra1) (rb0 :*: rb1) (rc0 :*: rc1) where
+--   gMerge (a0 :*: a1) (b0 :*: b1) = gMerge a0 b0 :*: gMerge a1 b1
+--
+--
+-- instance (GMerge ra rb rc) => GMerge (M1 D d ra) (M1 D d rb) (M1 D d rc) where
+--   gMerge (M1 fa) (M1 fb) = M1 $ gMerge fa fb
+--
+--
+-- instance (GMerge ra rb rc) => GMerge (M1 C d ra) (M1 C d rb) (M1 C d rc) where
+--   gMerge (M1 fa) (M1 fb) = M1 $ gMerge fa fb
+--
+--
+-- instance (Selector s, MergeField a b c) => GMerge (M1 S s (K1 R a)) (M1 S s (K1 R b)) (M1 S s (K1 R c)) where
+--   gMerge (M1 (K1 a)) (M1 (K1 b)) = M1 . K1 $ mergeField a b
+--
+--
+-- class MergeField a b c where
+--   mergeField :: a -> b -> c
 
-class GMerge ra rb rc where
-  gMerge :: ra p -> rb p -> rc p
-
-
-instance (GMerge ra0 rb0 rc0, GMerge ra1 rb1 rc1) => GMerge (ra0 :*: ra1) (rb0 :*: rb1) (rc0 :*: rc1) where
-  gMerge (a0 :*: a1) (b0 :*: b1) = gMerge a0 b0 :*: gMerge a1 b1
-
-
-instance (GMerge ra rb rc) => GMerge (M1 D d ra) (M1 D d rb) (M1 D d rc) where
-  gMerge (M1 fa) (M1 fb) = M1 $ gMerge fa fb
-
-
-instance (GMerge ra rb rc) => GMerge (M1 C d ra) (M1 C d rb) (M1 C d rc) where
-  gMerge (M1 fa) (M1 fb) = M1 $ gMerge fa fb
-
-
-instance (Selector s, MergeField a b c) => GMerge (M1 S s (K1 R a)) (M1 S s (K1 R b)) (M1 S s (K1 R c)) where
-  gMerge (M1 (K1 a)) (M1 (K1 b)) = M1 . K1 $ mergeField a b
-
-
-class MergeField a b c where
-  mergeField :: a -> b -> c
-
-
-instance MergeField (FieldName a) (Validated a) (FormField Validated a) where
-  mergeField = FormField
-
+-- instance MergeField (FieldName a) (Validated a) (FormField Validated a) where
+--   mergeField = FormField
 
 ------------------------------------------------------------------------------
 -- GConvert - combine two records with the same structure
@@ -496,64 +463,148 @@ instance MergeField (FieldName a) (Validated a) (FormField Validated a) where
 --   convertFields :: (FromSelector f g) => a f -> a g
 --   default convertFields :: (Generic (a f), Generic (a g), GConvert (Rep (a f)) (Rep (a g))) => a f -> a g
 --   convertFields x = to $ gConvert (from x)
-
-class GConvert ra rc where
-  gConvert :: ra p -> rc p
-
-
-instance (GConvert ra0 rc0, GConvert ra1 rc1) => GConvert (ra0 :*: ra1) (rc0 :*: rc1) where
-  gConvert (a0 :*: a1) = gConvert a0 :*: gConvert a1
-
-
-instance (GConvert ra rc) => GConvert (M1 D d ra) (M1 D d rc) where
-  gConvert (M1 fa) = M1 $ gConvert fa
-
-
-instance (GConvert ra rc) => GConvert (M1 C d ra) (M1 C d rc) where
-  gConvert (M1 fa) = M1 $ gConvert fa
-
-
-instance (Selector s, GenFieldFrom f g a, Field g a ~ g a) => GConvert (M1 S s (K1 R (f a))) (M1 S s (K1 R (g a))) where
-  gConvert (M1 (K1 inp)) =
-    let sel = selName (undefined :: M1 S s (K1 R (f a)) p)
-     in M1 . K1 $ genFieldFrom @f @g sel inp
-
-
-class GenFieldFrom inp f a where
-  genFieldFrom :: String -> inp a -> Field f a
-
-
--- instance GenFieldFrom Validated (FormField Validated) a where
---   genFieldFrom s = FormField (FieldName $ pack s)
 --
-
-instance GenFieldFrom val (FormField val) a where
-  genFieldFrom s = FormField (FieldName $ pack s)
-
+-- class GConvert ra rc where
+--   gConvert :: ra p -> rc p
+--
+--
+-- instance (GConvert ra0 rc0, GConvert ra1 rc1) => GConvert (ra0 :*: ra1) (rc0 :*: rc1) where
+--   gConvert (a0 :*: a1) = gConvert a0 :*: gConvert a1
+--
+--
+-- instance (GConvert ra rc) => GConvert (M1 D d ra) (M1 D d rc) where
+--   gConvert (M1 fa) = M1 $ gConvert fa
+--
+--
+-- instance (GConvert ra rc) => GConvert (M1 C d ra) (M1 C d rc) where
+--   gConvert (M1 fa) = M1 $ gConvert fa
+--
+--
+-- instance (Selector s, GenFieldFrom f g a, Field g a ~ g a) => GConvert (M1 S s (K1 R (f a))) (M1 S s (K1 R (g a))) where
+--   gConvert (M1 (K1 inp)) =
+--     let sel = selName (undefined :: M1 S s (K1 R (f a)) p)
+--      in M1 . K1 $ genFieldFrom @f @g sel inp
+--
+--
+-- class GenFieldFrom inp f a where
+--   genFieldFrom :: String -> inp a -> Field f a
+--
+--
+-- -- instance GenFieldFrom Validated (FormField Validated) a where
+-- --   genFieldFrom s = FormField (FieldName $ pack s)
+--
+-- instance GenFieldFrom val (FormField val) a where
+--   genFieldFrom s = FormField (FieldName $ pack s)
 
 ------------------------------------------------------------------------------
 
-class GCollect ra v where
-  gCollect :: ra p -> [v ()]
-
-
-instance GCollect U1 v where
-  gCollect _ = []
-
-
-instance (GCollect f v, GCollect g v) => GCollect (f :*: g) v where
-  gCollect (a :*: b) = gCollect a <> gCollect b
-
-
-instance (Selector s, ValidationState v) => GCollect (M1 S s (K1 R (v a))) v where
-  gCollect (M1 (K1 val)) = [convert val]
-
-
-instance (GCollect f v) => GCollect (M1 D d f) v where
-  gCollect (M1 f) = gCollect f
-
-
-instance (GCollect f v) => GCollect (M1 C c f) v where
-  gCollect (M1 f) = gCollect f
+-- class GCollect ra v where
+--   gCollect :: ra p -> [v ()]
+--
+--
+-- instance GCollect U1 v where
+--   gCollect _ = []
+--
+--
+-- instance (GCollect f v, GCollect g v) => GCollect (f :*: g) v where
+--   gCollect (a :*: b) = gCollect a <> gCollect b
+--
+--
+-- instance (Selector s, ValidationState v) => GCollect (M1 S s (K1 R (v a))) v where
+--   gCollect (M1 (K1 val)) = [convert val]
+--
+--
+-- instance (GCollect f v) => GCollect (M1 D d f) v where
+--   gCollect (M1 f) = gCollect f
+--
+--
+-- instance (GCollect f v) => GCollect (M1 C c f) v where
+--   gCollect (M1 f) = gCollect f
 
 ------------------------------------------------------------------------------
+
+newtype User = User Text
+  deriving newtype (FromParam)
+
+
+data TestForm f = TestForm
+  { name :: Field f Text
+  , age :: Field f Int
+  , user :: Field f User
+  }
+  deriving (Generic, FromFormF, GenFields Maybe, GenFields Validated)
+
+-- test :: (Hyperbole :> es) => Eff es (TestForm Identity)
+-- test = do
+--   tf <- formData
+--   pure tf
+
+-- formView :: (ViewAction (Action id)) => View id ()
+-- formView = do
+--   -- generate a ContactForm' FieldName
+--   let f = fieldNames @ContactForm
+--   form undefined (gap 10 . pad 10) $ do
+--     -- f.name :: FieldName Text
+--     -- f.name = FieldName "name"
+--     field f.name id $ do
+--       label "Contact Name"
+--       input Username (placeholder "contact name")
+--
+--     -- f.age :: FieldName Int
+--     -- f.age = FieldName "age"
+--     field f.age id $ do
+--       label "Age"
+--       input Number (placeholder "age" . value "0")
+--
+--     submit id "Submit"
+--
+--
+-- formView' :: (ViewAction (Action id)) => ContactForm Validated -> View id ()
+-- formView' contact = do
+--   -- generate a ContactForm' FieldName
+--   let f = formFields @ContactForm contact
+--   form undefined (gap 10 . pad 10) $ do
+--     -- f.name :: FieldName Text
+--     -- f.name = FieldName "name"
+--     field f.name id $ do
+--       label "Contact Name"
+--       input Username (placeholder "contact name")
+--
+--     -- f.age :: FieldName Int
+--     -- f.age = FieldName "age"
+--     field f.age id $ do
+--       label "Age"
+--       input Number (placeholder "age" . value "0")
+--
+--     field f.age id $ do
+--       label "Username"
+--       input Username (placeholder "username")
+--
+--     case f.age.value of
+--       Invalid t -> el_ (text t)
+--       Valid -> el_ "Username is available"
+--       _ -> none
+--
+--     submit id "Submit"
+--  where
+--   valStyle (Invalid _) = id
+--   valStyle Valid = id
+--   valStyle _ = id
+--
+--
+-- data ContactForm' = ContactForm'
+--   { name :: Text
+--   , age :: Int
+--   }
+--   deriving (Generic)
+-- instance FormParse ContactForm'
+--
+--
+-- formView'' :: (ViewAction (Action id)) => View id ()
+-- formView'' = do
+--   form undefined (gap 10 . pad 10) $ do
+--     -- f.name :: FieldName Text
+--     -- f.name = FieldName "name"
+--     field (FieldName "name") id $ do
+--       label "Contact Name"
+--       input Username (placeholder "contact name")

--- a/test/Test/FormSpec.hs
+++ b/test/Test/FormSpec.hs
@@ -12,15 +12,14 @@ data Example f = Example
   , age :: Field f Int
   , whatever :: Field f (Maybe Float)
   }
-  deriving (Generic)
-instance Form Example Maybe
+  deriving (Generic, FromFormF, GenFields Maybe)
 
 
 spec :: Spec
 spec = do
   describe "forms" $ do
     it "should parse a form" $ do
-      case formParse @Example [("message", "hello"), ("age", "23"), ("whatever", "")] of
+      case fromForm @(Example Identity) [("message", "hello"), ("age", "23"), ("whatever", "")] of
         Left e -> fail $ show e
         Right a -> do
           a.message `shouldBe` "hello"


### PR DESCRIPTION
Forcing the user to use Higher Kinded Types for forms makes certain use-cases impossible or difficult. For example, in #79, @yellowbean wanted to create forms dynamically, but would've had to fight the system. 

This PR simplifies and clarifies the form system:
1. Split the Form class into `FromForm`, `FromFormF` and `GenFields`
2. Removes the `FormField` type, which contained both the value and the field name. It's easier to use the same selector twice. 
3. Simplifies deriving in both cases
4. Removes the association of Validation types to the Form instance

It is now possible to create forms dynamically and intuitively like this:

```
-- Forms can be pretty simple. Just a type that can be parsed
data ContactForm = ContactForm
  { name :: Text
  , age :: Int
  }
  deriving (Generic, FromForm)

-- and a view that displays an input for each field
formView :: View FormView ()
formView = do
  form Submit (gap 10 . pad 10) $ do
    el Style.h1 "Add Contact"

    -- You must make sure these names match the field names used by FormParse / formData
    field "name" id $ do
      label "Contact Name"
      input Username (inp . placeholder "contact name")
```

If you are using the Higher Kinded Types, it now looks like this:

```
-- Alternatively, use Higher Kinded Types, and Hyperbole can guarantee the field names are the same
--
-- ContactForm' Identity is exactly the same as ContactForm:
-- ContactForm' { name :: Text, age :: Int }
--
-- ContactForm' FieldName:
-- ContactForm' { name :: FieldName Text, age :: FieldName Int }
--
-- ContactForm' Maybe:
-- ContactForm' { name :: Maybe Text, age :: Maybe Int }
--
-- You still have to remember to include all the fields somewhere in the form
data ContactForm' f = ContactForm'
  { name :: Field f Text
  , age :: Field f Int
  }
  deriving (Generic, FromFormF, GenFields FieldName)

formView' :: View FormView ()
formView' = do
  -- generate a ContactForm' FieldName
  let f = fieldNames @ContactForm'
  form Submit (gap 10 . pad 10) $ do
    el Style.h1 "Add Contact"

    -- f.name :: FieldName Text
    -- f.name = FieldName "name"
    field f.name id $ do
      label "Contact Name"
      input Username (inp . placeholder "contact name")
```
