### PR TITLE
Fixed source links in example app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for hyperbole
 
+## 0.4.4 -- 2025-03-09
+
+* fixed source links in examples
+
 ## 0.4.3 -- 2024-01-31
 
 * Bug fixes and improvements

--- a/examples/Example/View/Layout.hs
+++ b/examples/Example/View/Layout.hs
@@ -24,7 +24,7 @@ exampleLayout rt pageView = do
     row (bg White) $ do
       pageView
  where
-  sourceUrl = "https://github.com/seanhess/hyperbole/blob/0.4/examples/" <> routeSource rt
+  sourceUrl = "https://github.com/seanhess/hyperbole/blob/0.4/example/" <> routeSource rt
 
   routeSource :: AppRoute -> Url
   routeSource = \case

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           hyperbole
-version:        0.4.4
+version:        0.4.3
 synopsis:       Interactive HTML apps using type-safe serverside Haskell
 description:    Interactive serverside web framework Inspired by HTMX, Elm, and Phoenix LiveView
 category:       Web, Network

--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           hyperbole
-version:        0.4.3
+version:        0.4.4
 synopsis:       Interactive HTML apps using type-safe serverside Haskell
 description:    Interactive serverside web framework Inspired by HTMX, Elm, and Phoenix LiveView
 category:       Web, Network


### PR DESCRIPTION
At the moment, clicking any "View Source" links in the example app will result in a 404 because for the 0.4 tag, the directory is `example` not `examples`. The other alternative would be to update the 0.4 tag to point to the latest version of the repo, which does indeed have an `examples` directory. 
