### PR TITLE
Add an example for OAuth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ result
 client/dist/hyperbole.js.LICENSE.txt
 client/dist/hyperbole.js.map
 Session.vim
+.cabal.nix

--- a/examples/Example/App.hs
+++ b/examples/Example/App.hs
@@ -49,6 +49,7 @@ import Example.Page.Filter qualified as Filter
 import Example.Page.Forms qualified as Forms
 import Example.Page.Intro qualified as Intro
 import Example.Page.Javascript qualified as Javascript
+import Example.Page.OAuth2 qualified as OAuth2
 import Example.Page.Requests qualified as Requests
 import Example.Page.State.Actions qualified as Actions
 import Example.Page.State.Effects qualified as Effects
@@ -130,6 +131,7 @@ app users count = do
   router AtomicCSS = runPage CSS.page
   router Todos = runPage Todo.page
   router Javascript = runPage Javascript.page
+  router OAuth2 = runPage $ OAuth2.page
   router Simple = redirect (routeUri Intro)
   router Counter = redirect (routeUri Intro)
   router Test = runPage Test.page

--- a/examples/Example/AppRoute.hs
+++ b/examples/Example/AppRoute.hs
@@ -21,6 +21,7 @@ data AppRoute
   | Todos
   | Errors
   | Javascript
+  | OAuth2
   | Test
   deriving (Eq, Generic, Show)
 instance Route AppRoute where

--- a/examples/Example/Page/OAuth2.hs
+++ b/examples/Example/Page/OAuth2.hs
@@ -197,17 +197,6 @@ renderTokenTable tok = table (formatToken tok) $ do
   tcol (th "Field" ~ textAlign AlignLeft) (td . text . fst)
   tcol (th "Value" ~ textAlign AlignLeft) (td . text . snd)
 
--- NOTE: Moving "col ~ gap 15" right after "hyper Contents" like so:
--- @
--- hyper Contents $ col ~ gap 15 $ viewContent ...
--- @
--- has unintended behaviour. "col ~ gap 15" for some reason does not have an
--- effect once the user logs in and then logs out.
---
--- It looks like everything after "hyper Contents" is replaced on a change. So
--- the behaviour described above makes sense in that case and I have misused the
--- view creation.
---
 viewContent :: ViewState -> View Contents ()
 viewContent Unauthorized = col ~ gap 15 $ unauthorizedContent
 viewContent (PreAuthorized etok) =

--- a/examples/Example/Page/OAuth2.hs
+++ b/examples/Example/Page/OAuth2.hs
@@ -1,0 +1,20 @@
+module Example.Page.OAuth2 (page) where
+
+--------------------------------------------------------------------------------
+-- Imports
+--------------------------------------------------------------------------------
+
+import Example.View.Layout
+import Web.Hyperbole
+
+import qualified Example.AppRoute as Route
+
+--------------------------------------------------------------------------------
+-- Page
+--------------------------------------------------------------------------------
+
+page :: (Hyperbole :> es) => Eff es (Page '[])
+page = do
+  pure $ exampleLayout Route.OAuth2 $ do
+    example "OAuth2" "Example/Page/OAuth2.hs" $ do
+      el "Hello, World!"

--- a/examples/Example/Page/OAuth2.hs
+++ b/examples/Example/Page/OAuth2.hs
@@ -1,20 +1,177 @@
-module Example.Page.OAuth2 (page) where
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example.Page.OAuth2
+  ( OAuth2.OAuth2
+  , page
+  , getOAuth2
+  ) where
 
 --------------------------------------------------------------------------------
 -- Imports
 --------------------------------------------------------------------------------
 
+import Control.Monad (replicateM, when)
+import Data.Maybe (fromMaybe)
+import Data.Text (pack, Text)
+import Network.URI (parseURI)
+import System.Environment (getEnv)
+import System.Random (randomRIO)
+
+import Data.ByteString.Builder qualified as BB
+import Data.ByteString.Char8 qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Example.AppRoute qualified as Route
+import Network.OAuth.OAuth2 qualified as OAuth2
+import URI.ByteString qualified as URI
+
+import Effectful
+import Effectful.Reader.Dynamic
 import Example.View.Layout
+import Web.Atomic.CSS
 import Web.Hyperbole
 
-import qualified Example.AppRoute as Route
+--------------------------------------------------------------------------------
+-- Types
+--------------------------------------------------------------------------------
+
+data DummyUser = DummyUser
+  { username :: Text
+  , password :: Text
+  }
+
+-- TODO: Add expiry to this state
+data RandomState = RandomState String
+  deriving (Generic, Show, ToJSON, FromJSON, Session)
+
+data Token = Token OAuth2.OAuth2Token
+  deriving (Generic, Show, ToJSON, FromJSON, Session)
+
+--------------------------------------------------------------------------------
+-- Environment
+--------------------------------------------------------------------------------
+
+getEnvText :: String -> IO Text
+getEnvText = fmap pack . getEnv
+
+getOAuth2 :: IO OAuth2.OAuth2
+getOAuth2 =
+  OAuth2.OAuth2
+    <$> getEnvText "OAUTH2_CLIENT_ID"
+    <*> getEnvText "OAUTH2_CLIENT_SECRET"
+    <*> getEnvURIRef "OAUTH2_AUTHORIZE_ENDPOINT"
+    <*> getEnvURIRef "OAUTH2_TOKEN_ENDPOINT"
+    <*> getEnvURIRef "OAUTH2_REDIRECT_URI"
+  where
+  getEnvURIRef var = do
+    res <- BS.pack <$> getEnv var
+    case URI.parseURI URI.strictURIParserOptions res of
+      Left err -> error $ "getEnvURIRef: " ++ show err
+      Right val -> pure val
+
+getDummyUser :: IO DummyUser
+getDummyUser = do
+  DummyUser
+    <$> getEnvText "OAUTH2_DUMMY_USERNAME"
+    <*> getEnvText "OAUTH2_DUMMY_PASSWORD"
+
+--------------------------------------------------------------------------------
+-- Authentication
+--------------------------------------------------------------------------------
+
+-- Convert URIRef Absolute (uri-bytestring) to URI (network-uri)
+--
+-- NOTE: It is more efficient to construct the URI record but for the time being
+-- we'll do things in a simple and stupid way.
+toURI :: URI.URIRef URI.Absolute -> URI
+toURI uriRef =
+  fromMaybe (error "toURI: Unable to parse URI")
+    $ parseURI
+    $ BS.unpack
+    $ BSL.toStrict
+    $ BB.toLazyByteString
+    $ URI.serializeURIRef uriRef
+
+redirectToAuthServer ::
+  (Reader (OAuth2.OAuth2) :> es, Hyperbole :> es, IOE :> es) => Eff es a
+redirectToAuthServer = do
+  randomState <- replicateM 15 (randomRIO ('a', 'z'))
+  oauth2Obj <- ask
+  saveSession (RandomState randomState)
+  redirect $ toURI $
+    OAuth2.authorizationUrlWithParams
+      [ ("scope", "photo+offline_access")
+      , ("state", BS.pack randomState)
+      ]
+      oauth2Obj
+
+lookupExchangeToken :: (Hyperbole :> es) => Eff es (Maybe OAuth2.ExchangeToken)
+lookupExchangeToken = do
+  mRespState <- lookupParam "state"
+  mSavedState <- lookupSession @RandomState
+  mCode <- lookupParam "code"
+  pure $ do
+    respState <- mRespState
+    (RandomState savedState) <- mSavedState
+    when (respState /= savedState)
+      $ error "parseExchangeToken: The state does not match"
+    code_ <- mCode
+    pure $ OAuth2.ExchangeToken code_
+
+--------------------------------------------------------------------------------
+-- Views
+--------------------------------------------------------------------------------
+
+data Contents = Contents
+  deriving (Generic, ViewId)
+
+instance (Reader (OAuth2.OAuth2) :> es, IOE :> es) => HyperView Contents es where
+  data Action Contents
+    = Login
+    | Logout
+    deriving (Generic, ViewAction)
+  update Login = redirectToAuthServer
+  update Logout = do
+    deleteSession @Token
+    du <- liftIO getDummyUser
+    pure $ viewContent $ Unauthorized du
 
 --------------------------------------------------------------------------------
 -- Page
 --------------------------------------------------------------------------------
 
-page :: (Hyperbole :> es) => Eff es (Page '[])
+data ViewState = Authorized OAuth2.OAuth2Token | Unauthorized DummyUser
+
+setup :: (Hyperbole :> es, IOE :> es) => Eff es ViewState
+setup = do
+  mtoken <- lookupSession @Token
+  case mtoken of
+    Just (Token tok) -> pure $ Authorized tok
+    Nothing -> do
+      mExchangeTok <- lookupExchangeToken
+      case mExchangeTok of
+        Nothing -> do
+          du <- liftIO getDummyUser
+          pure $ Unauthorized du
+        Just exchangeTok -> do
+          oauthTok <- error "Unimplemented"
+          saveSession (Token oauthTok)
+          pure $ Authorized oauthTok
+
+page :: (Hyperbole :> es, IOE :> es) => Eff es (Page '[Contents])
 page = do
+  vs <- setup
   pure $ exampleLayout Route.OAuth2 $ do
     example "OAuth2" "Example/Page/OAuth2.hs" $ do
-      el "Hello, World!"
+      col ~ embed $ hyper Contents $ viewContent vs
+
+viewContent :: ViewState -> View Contents ()
+viewContent (Unauthorized du) = unauthorizedContent du
+viewContent (Authorized tok) = authorizedContent tok
+
+unauthorizedContent :: DummyUser -> View Contents ()
+unauthorizedContent _ = do
+  el "Unauthorized content"
+
+authorizedContent :: OAuth2.OAuth2Token -> View Contents ()
+authorizedContent _ =
+  el "Authorized content"

--- a/examples/Example/View/Layout.hs
+++ b/examples/Example/View/Layout.hs
@@ -106,6 +106,7 @@ exampleMenu current = do
   exampleLink (Contacts ContactsAll)
   exampleLink Javascript
   exampleLink Errors
+  exampleLink OAuth2
  where
   -- example Errors
 
@@ -135,6 +136,7 @@ routeTitle (Data Filter) = "Filters"
 routeTitle (Data Autocomplete) = "Autocomplete"
 routeTitle Errors = "Error Handling"
 routeTitle Todos = "TodoMVC"
+routeTitle OAuth2 = "OAuth2"
 routeTitle r = cs $ toWords $ fromHumps $ show r
 
 pageDescription :: AppRoute -> View c ()

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -106,6 +106,7 @@ executable examples
     , effectful
     , file-embed
     , foreign-store
+    , hoauth2
     , http-api-data
     , http-types
     , hyperbole

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -108,8 +108,11 @@ executable examples
     , foreign-store
     , hoauth2
     , http-api-data
+    , http-client
+    , http-client-tls
     , http-types
     , hyperbole
+    , mtl
     , network
     , network-uri
     , random

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -111,12 +111,14 @@ executable examples
     , http-types
     , hyperbole
     , network
+    , network-uri
     , random
     , safe
     , string-conversions
     , string-interpolate
     , text
     , time
+    , uri-bytestring
     , wai
     , wai-middleware-static
     , wai-websockets

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -65,6 +65,7 @@ executable examples
       Example.Page.FormValidation
       Example.Page.Intro
       Example.Page.Javascript
+      Example.Page.OAuth2
       Example.Page.Requests
       Example.Page.Simple
       Example.Page.State.Actions

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -49,6 +49,7 @@ dependencies:
   - websockets
   - cookie
   - hyperbole
+  - hoauth2
 
 executables:
   examples:

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -50,6 +50,8 @@ dependencies:
   - cookie
   - hyperbole
   - hoauth2
+  - uri-bytestring
+  - network-uri
 
 executables:
   examples:

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -52,6 +52,9 @@ dependencies:
   - hoauth2
   - uri-bytestring
   - network-uri
+  - http-client
+  - http-client-tls
+  - mtl
 
 executables:
   examples:


### PR DESCRIPTION
Hi @seanhess 

Please review the OAuth2 example implementation. I've added a few inline
comments prefixed with `NOTE` describing some issues I faced. Overall, this 
library is very promising.

I've tested this locally using a mock OAuth server.

Mock Server:
```
npx oauth2-mock-server
```

Testing the example locally:
```
export OAUTH2_CLIENT_ID="Some_Dummy_client_ID"
export OAUTH2_CLIENT_SECRET="Some_Dummy_Client_Secret"
export OAUTH2_AUTHORIZE_ENDPOINT="http://localhost:8080/authorize"
export OAUTH2_TOKEN_ENDPOINT="http://localhost:8080/token"
export OAUTH2_REDIRECT_URI="http://localhost:3000/oauth2"
cabal run examples
```

To run this example in production:
1. Register an OAuth Client
2. Populate the envs properly during deployment

The `scope=email` is currently hardcoded. We don't use the access token to fetch
futher informaion, so the scope is meaningless.