### PR TITLE
Add missing test dependency

### DIFF
--- a/hyperbole.cabal
+++ b/hyperbole.cabal
@@ -140,6 +140,7 @@ test-suite test
       DerivingStrategies
       DeriveAnyClass
   ghc-options: -Wall -fdefer-typed-holes -threaded -rtsopts -with-rtsopts=-N -F -pgmF=skeletest-preprocessor
+  build-tool-depends: skeletest:skeletest-preprocessor
   build-depends:
       aeson >=2.2.0.0
     , atomic-css ==0.1.*


### PR DESCRIPTION
Fixes the following build error:

```
$ cabal build                                                                 
Resolving dependencies...                                                                                                               
Build profile: -w ghc-9.6.7 -O1                                     
In order, the following will be built (use -v for more details):    
 - hyperbole-0.5.0 (test:test) (first run)                        
Preprocessing test suite 'test' for hyperbole-0.5.0...              
Building test suite 'test' for hyperbole-0.5.0...                   
ghc-9.6.7: could not execute: skeletest-preprocessor       
Error: [Cabal-7125]                                                 
Failed to build test:test from hyperbole-0.5.0.             
```

The added line is mentioned here: https://github.com/brandonchinn178/skeletest?tab=readme-ov-file#quickstart