### PR TITLE
Fix: HTML nodes being silently dropped in View's Monad instance

### DIFF
--- a/src/Web/Hyperbole/View/Types.hs
+++ b/src/Web/Hyperbole/View/Types.hs
@@ -56,9 +56,9 @@ instance Monad (View ctx) where
   (>>=) :: forall a b. View ctx a -> (a -> View ctx b) -> View ctx b
   -- TEST: appending Empty
   View ea >>= famb = View $ do
-    a :: a <- (.value) <$> ea
-    let View eb :: View ctx b = famb a
-    eb
+    ha <- ea
+    let View eb = famb ha.value
+    (ha >>) <$> eb
 
 
 -- Context -----------------------------------------


### PR DESCRIPTION
Hello,

When using `>>=` directly, or when `ApplicativeDo` is enabled (which introduces a `join` call that goes through `>>=`), all but the last element in a `do` block would be silently dropped from the rendered HTML.

For example:
```haskell
{-# LANGUAGE ApplicativeDo #-}
col $ do
  el "One"
  el "Two"
  el "Three"
```
or
```haskell
col $ el "One" >>= \_ -> el "Two" >>= \_ -> el "Three"
```
would render only "Three".

## Cause

The `>>=` implementation of `View` was extracting only the return value from the first action via `(.value) <$> ea`, discarding its `Html` nodes entirely:
```haskell
View ea >>= famb = View $ do
  a <- (.value) <$> ea   -- nodes from ea are thrown away
  let View eb = famb a
  eb
```

## Fix

Run the first action fully to obtain its `Html` value, then delegate node accumulation to `Html`'s own `>>`, which correctly concatenates both node lists:
```haskell
View ea >>= famb = View $ do
  ha <- ea
  let View eb = famb ha.value
  (ha >>) <$> eb
```

## Notes

The bug was not visible when using plain `do` notation without `ApplicativeDo`, because GHC desugars it to `>>` which is defined as `(*>)` and bypasses `>>=` entirely. The bug only manifests when `>>=` is called directly or through `join`.