### PR TITLE
nix(flake): add pre-commit hooks for `oxlint`+`oxfmt`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,10 @@
 
         pre-commit = pre-commit-hooks.lib.${system}.run {
           src = src;
+          excludes = [
+            "^client/node_modules/"
+            "^client/dist/"
+          ];
           hooks = {
             hlint.enable = true;
             fourmolu.enable = true;
@@ -135,11 +139,35 @@
               args = [ "--no-telemetry" ];
             };
             check-merge-conflicts.enable = true;
+            # `oxlint` uses the lockfile-pinned version here (`pre-commit-hooks` may provide a different one)
+            oxlint = {
+              enable = true;
+              name = "oxlint";
+              entry = "npm run --prefix client lint";
+              language = "system";
+              files = "^client/";
+              pass_filenames = false;
+            };
+            # `oxfmt` uses the lockfile-pinned version here (`pre-commit-hooks` may provide a different one)
+            oxfmt = {
+              enable = true;
+              name = "oxfmt (check)";
+              entry = "npm run --prefix client fmt";
+              language = "system";
+              files = "^client/";
+              pass_filenames = false;
+            };
           };
         };
 
         shellCommon = version: {
-          inherit (pre-commit) shellHook;
+          shellHook = ''
+            ${pre-commit.shellHook}
+            # `oxlint`/`oxfmt` hooks require lockfile-pinned binaries from `node_modules`
+            if [ ! -d "client/node_modules" ]; then
+              npm install --prefix client
+            fi
+          '';
           buildInputs = with pkgs.haskell.packages."ghc${version}"; [
             pkgs-node.nodejs_24
             cabal-install
@@ -210,65 +238,63 @@
             value = pkgs.runCommand "ghc${version}-check-demo" {
               buildInputs = [
                 (exe version)
-              ] ++ self.devShells.${system}."ghc${version}-shell".buildInputs;
+              ]
+              ++ self.devShells.${system}."ghc${version}-shell".buildInputs;
             } "type demo; type docgen; CABAL_CONFIG=/dev/null cabal --dry-run repl; touch $out";
           }) ghcVersions
         );
 
-        apps =
-          {
-            default = self.apps.${system}."ghc966-${demoName}";
-          }
-          // builtins.listToAttrs (
-            map (version: {
+        apps = {
+          default = self.apps.${system}."ghc966-${demoName}";
+        }
+        // builtins.listToAttrs (
+          map (version: {
+            name = "ghc${version}-${demoName}";
+            value = {
+              type = "app";
+              program = "${exe version}/bin/demo";
+            };
+          }) ghcVersions
+        );
+
+        packages = {
+          default = self.packages.${system}."ghc982-${packageName}";
+          docker = self.packages.${system}."ghc982-docker";
+        }
+        // builtins.listToAttrs (
+          builtins.concatMap (version: [
+            {
               name = "ghc${version}-${demoName}";
-              value = {
-                type = "app";
-                program = "${exe version}/bin/demo";
-              };
-            }) ghcVersions
-          );
+              value = ghcPkgs."ghc${version}".${demoName};
+            }
+            {
+              name = "ghc${version}-docker";
+              value = docker version;
+            }
+            {
+              name = "ghc${version}-${packageName}";
+              value = ghcPkgs."ghc${version}".${packageName};
+            }
+          ]) ghcVersions
+        );
 
-        packages =
-          {
-            default = self.packages.${system}."ghc982-${packageName}";
-            docker = self.packages.${system}."ghc982-docker";
-          }
-          // builtins.listToAttrs (
-            builtins.concatMap (version: [
-              {
-                name = "ghc${version}-${demoName}";
-                value = ghcPkgs."ghc${version}".${demoName};
+        devShells = {
+          default = self.devShells.${system}.ghc982-shell;
+        }
+        // builtins.listToAttrs (
+          map (version: {
+            name = "ghc${version}-shell";
+            value = ghcPkgs."ghc${version}".shellFor (
+              shellCommon version
+              // {
+                packages = p: [
+                  p.${packageName}
+                  p.${demoName}
+                ];
               }
-              {
-                name = "ghc${version}-docker";
-                value = docker version;
-              }
-              {
-                name = "ghc${version}-${packageName}";
-                value = ghcPkgs."ghc${version}".${packageName};
-              }
-            ]) ghcVersions
-          );
-
-        devShells =
-          {
-            default = self.devShells.${system}.ghc982-shell;
-          }
-          // builtins.listToAttrs (
-            map (version: {
-              name = "ghc${version}-shell";
-              value = ghcPkgs."ghc${version}".shellFor (
-                shellCommon version
-                // {
-                  packages = p: [
-                    p.${packageName}
-                    p.${demoName}
-                  ];
-                }
-              );
-            }) ghcVersions
-          );
+            );
+          }) ghcVersions
+        );
       }
     );
 }


### PR DESCRIPTION
## Notes 
- #205 needs to be merged before CI will run successfully.
- Everything from line 241 are just formatting changes.


## Examples

- `oxfmt` failed

```sh
gc -S

check-merge-conflicts....................................................Passed
flake-checker........................................(no files to check)Skipped
fourmolu.............................................(no files to check)Skipped
hlint................................................(no files to check)Skipped
nixfmt-rfc-style.....................................(no files to check)Skipped
oxfmt (check)............................................................Failed
- hook id: oxfmt
- files were modified by this hook

```

## Example

- `oxlint` failed

```sh
gc -S

check-merge-conflicts....................................................Passed
flake-checker........................................(no files to check)Skipped
fourmolu.............................................(no files to check)Skipped
hlint................................................(no files to check)Skipped
nixfmt-rfc-style.....................................(no files to check)Skipped
oxfmt (check)............................................................Passed
oxlint...................................................................Failed
- hook id: oxlint
- exit code: 1

> web-ui@0.6.0 lint
> oxlint


  × typescript(TS6133): '_unused' is declared but its value is never read.
   ╭─[src/lib.ts:1:7]
 1 │ const _unused = 42
   ·       ───────
 2 │
   ╰────

Found 0 warnings and 1 error.
Finished in 136ms on 14 files with 110 rules using 8 threads.
```