### PR TITLE
feat(ci): nix build `ghc967` + `ghc984` + `ghc9103` + `ghc9124`

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -25,5 +25,10 @@ jobs:
         with:
           extra_nix_config: "accept-flake-config = true"
 
+      - uses: cachix/cachix-action@v17
+        with:
+          name: hyperbole
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: build (incl. tests)
         run: nix build .#ghc${{ matrix.ghc_version }}-hyperbole

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         ghc_version:
           - "967"
-          # - "984"
-          # - "9103"
-          # - "9124"
+          - "984"
+          - "9103"
+          - "9124"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: "accept-flake-config = true"
 
       - name: build (incl. tests)
         run: nix build .#ghc${{ matrix.ghc_version }}-hyperbole

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,27 @@
+name: nix
+
+on:
+  push:
+    branches: ["main", "ci"]
+  pull_request:
+
+jobs:
+  build:
+    name: ghc${{ matrix.ghc_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc_version:
+          - "967"
+          # - "984"
+          # - "9103"
+          # - "9124"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: build (incl. tests)
+        run: nix build .#ghc${{ matrix.ghc_version }}-hyperbole

--- a/.packcheck.ignore
+++ b/.packcheck.ignore
@@ -11,6 +11,7 @@ demo/
 .dockerignore
 .github/workflows/haskell.yaml
 .github/workflows/packcheck.yaml
+.github/workflows/nix.yaml
 .gitignore
 .hlint.yaml
 .packcheck.ignore


### PR DESCRIPTION
CI runs Nix builds in a time range from ~2min up to ~50min (!!). See [here](https://github.com/seanhess/hyperbole/actions/runs/25866643932/usage) or [here](https://github.com/seanhess/hyperbole/actions/runs/25868392279/usage)). That's because of usage or non-usage of cachix.

To speed up builds, it's recommended to add [`cachix-action` ](https://github.com/cachix/cachix-action) to the `nix.yaml` workflow. 

To run `cachix-action` properly, secrets `CACHIX_SIGNING_KEY` and/or `CACHIX_AUTH_TOKEN` are needed to set up at GitHub. It seems anyone has already created an account for Hyperbole at Cachix https://hyperbole.cachix.org where those keys can be created.  

How to?
- `cachix-action`  -> examples -> [Write cache with auth token](https://github.com/cachix/cachix-action#write-cache-with-auth-token) 
- Nix -> Recipes -> [Continuous integration with GitHub Actions](https://nix.dev/guides/recipes/continuous-integration-github-actions). 
 