### PR TITLE
fix: remove duplicated ghc constraints

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,9 +30,6 @@ tested-with:
   - GHC == 9.10.3
   - GHC == 9.8.4
   - GHC == 9.6.7
-  - GHC == 9.8.4
-  - GHC == 9.10.3
-  - GHC == 9.12.4
 
 default-extensions:
   - OverloadedStrings


### PR DESCRIPTION
It might be an artifact of a previous merge (conflict).

No effect of `hyperbole.cabal`.

```sh
hpack
  hyperbole.cabal is up-to-date
``` 