### PR TITLE
fix(nix): `hyperbole-oauth2` is missing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1777997741,
-        "narHash": "sha256-8jBvWbE/m8McQAPXszl62M5RM8BtRNl/1nOP9Spfsm4=",
+        "lastModified": 1778779594,
+        "narHash": "sha256-PEP6MnQXgr0+0/kP/utcxTv3aYqF3h9v6UvNFpySAyk=",
         "owner": "seanhess",
         "repo": "atomic-css",
-        "rev": "01b457012fbe496fb1dbab084074c2880761dce9",
+        "rev": "8e9ab916c8a718da6bd9337a9d0977dd19f691c4",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,16 @@
           ];
         };
 
+        oauth2-src = nix-filter.lib {
+          root = ./hyperbole-oauth2;
+          include = [
+            "src"
+            (nix-filter.lib.matchExt "hs")
+            ./hyperbole-oauth2/hyperbole-oauth2.cabal
+            ./hyperbole-oauth2/README.md # required by `extra-doc-files` in `hyperbole-oauth2.cabal`
+          ];
+        };
+
         # Merges filtered `demo` + `docs` sources into `$out`.
         # Needed to solve `demo/docs` -> `../docs` symlink issue Nix has before.
         # Named "demo" so the store path is `/nix/store/<hash>-demo`.
@@ -152,6 +162,7 @@
                 hfinal: hprev: {
                   ${demoName} = hfinal.callCabal2nix demoName demo-docs-src { };
                   docgen = hfinal.callCabal2nix "docgen" docgen-src { };
+                  hyperbole-oauth2 = hfinal.callCabal2nix "hyperbole-oauth2" oauth2-src { };
                 }
               )
             );


### PR DESCRIPTION
required by `hyperbole-demo`.

Error:

```sh
error: function 'anonymous lambda' called without required argument 'hyperbole-oauth2'
         at /nix/store/l30yk4520zwdwvk4zsva5zmnhda6aslw-cabal2nix-hyperbole-demo/default.nix:1:1:
```