### PR TITLE
fix(example): view state did not match embedded example code

### DIFF
--- a/demo/App/Page/State.hs
+++ b/demo/App/Page/State.hs
@@ -51,7 +51,7 @@ page = do
       markdocs $(embedFile "docs/state-viewstate.md")
 
       example $(moduleSourceNamed "Example.State.ViewState") $ do
-        hyperState ViewState.CounterState 0 ViewState.viewCount
+        hyperState ViewState.CounterState 10 ViewState.viewCount
 
     section BrowserQuery $ do
       markdocs $(embedFile "docs/state-browser.md")

--- a/demo/Example/State/ViewState.hs
+++ b/demo/Example/State/ViewState.hs
@@ -9,7 +9,7 @@ import Web.Hyperbole.HyperView
 page :: (Hyperbole :> es) => Page es '[Counter]
 page = do
   pure $ do
-    hyperState CounterState 1 viewCount
+    hyperState CounterState 10 viewCount
 
 data Counter = CounterState
   deriving (Generic)


### PR DESCRIPTION
0 vs. 1. Set both to 10 now.