### PR TITLE
fix: remove redundant call of `mobileFriendly`

### DIFF
--- a/src/Web/Hyperbole/Document.hs
+++ b/src/Web/Hyperbole/Document.hs
@@ -48,7 +48,7 @@ data DocumentHead = DocumentHead
 @
 -}
 quickStartDocument :: BL.ByteString -> BL.ByteString
-quickStartDocument = document (mobileFriendly >> quickStart)
+quickStartDocument = document quickStart
 
 
 -- | A simple mobile-friendly header with all required embeds and live reload


### PR DESCRIPTION
as it's already called in `quickStart`