### PR TITLE
update/fix `filter` example 

### DIFF
--- a/demo/Example/DataLists/Autocomplete.hs
+++ b/demo/Example/DataLists/Autocomplete.hs
@@ -49,8 +49,7 @@ instance (IOE :> es) => HyperView LiveSearch es where
 
 selectedView :: ProgrammingLanguage -> View LiveSearch ()
 selectedView selected = do
-  col ~ gap 10 $ do
-    Filter.chosenView selected
+  Filter.chosenView selected (Select Nothing)
 
 liveSearchView :: [ProgrammingLanguage] -> Int -> Text -> View LiveSearch ()
 liveSearchView langs current term = do

--- a/demo/Example/DataLists/Filter.hs
+++ b/demo/Example/DataLists/Filter.hs
@@ -101,7 +101,7 @@ languagesView filters = do
 filtersView :: Filters -> View Languages ()
 filtersView filters = do
   el ~ stack . grow $ do
-    search SearchTerm 250 @ placeholder "filter programming languages" . value filters.term . autofocus ~ border 1 . pad 10
+    search SearchTerm 250 @ onKeyDown Escape SearchTerm . placeholder "filter programming languages" . value filters.term . autofocus ~ border 1 . pad 10
     clearButton SearchTerm filters.term
 
   row $ do

--- a/demo/Example/DataLists/Filter.hs
+++ b/demo/Example/DataLists/Filter.hs
@@ -10,6 +10,7 @@ import Data.Text (Text, pack)
 import Effectful hiding (Dynamic)
 import Example.Colors
 import Example.Data.ProgrammingLanguage (LanguageFamily (..), ProgrammingLanguage (..), TypeFeature (..), allLanguages, isMatchLanguage)
+import Example.Style.Cyber (btn)
 import Example.View.Icon as Icon
 import Example.View.Inputs (toggleCheckbox)
 import Example.View.Layout
@@ -50,7 +51,7 @@ instance (IOE :> es) => HyperView Languages es where
 
   update = \case
     Select lang -> do
-      pure $ chosenView lang
+      pure $ chosenView lang SetFamily
     SearchTerm -> do
       term <- inputValue
       filters <- modFilters $ \f -> f{term}
@@ -141,12 +142,14 @@ clearButton clear term =
       "" -> display None
       _ -> id
 
-chosenView :: ProgrammingLanguage -> View c ()
-chosenView lang = do
-  row ~ gap 10 $ do
-    el "You chose:"
-    el $ text lang.name
-  el ~ (if lang.name == "Haskell" then id else display None) $ "You are as wise as you are attractive"
+chosenView :: (ViewAction (Action id)) => ProgrammingLanguage -> Action id -> View id ()
+chosenView lang back = do
+  col ~ gap 10 $ do
+    row ~ gap 10 $ do
+      el "You chose:"
+      el $ text lang.name
+    el ~ (if lang.name == "Haskell" then id else display None) $ "You are as wise as you are attractive"
+    row $ button back ~ btn $ "Back"
 
 resultsTable :: (ViewAction (Action id)) => (ProgrammingLanguage -> Action id) -> [ProgrammingLanguage] -> View id ()
 resultsTable onSelect langs = do

--- a/src/Web/Hyperbole/HyperView/Input.hs
+++ b/src/Web/Hyperbole/HyperView/Input.hs
@@ -3,7 +3,7 @@
 
 module Web.Hyperbole.HyperView.Input where
 
-import Data.Aeson (FromJSON, ToJSON (toJSON), Value (Null))
+import Data.Aeson (FromJSON, ToJSON)
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -55,9 +55,7 @@ option
   -> View (Option id opt) ()
 option opt cnt = do
   os :: Option id opt <- viewId
-  -- For "null" like arguments such as `Nothing` set `value=""` (but never `value="null"`, which breaks the round-trip)
-  let val = if toJSON opt == Null then "" else encodeArgument opt
-  tag "option" @ att "value" val @ selected (os.defaultOption == opt) $ text cnt
+  tag "option" @ att "value" (encodeArgument opt) @ selected (os.defaultOption == opt) $ text cnt
 
 
 -- | sets selected = true if the 'dropdown' predicate returns True

--- a/src/Web/Hyperbole/HyperView/Input.hs
+++ b/src/Web/Hyperbole/HyperView/Input.hs
@@ -3,7 +3,7 @@
 
 module Web.Hyperbole.HyperView.Input where
 
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON (toJSON), Value (Null))
 import Data.String.Conversions (cs)
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -55,7 +55,9 @@ option
   -> View (Option id opt) ()
 option opt cnt = do
   os :: Option id opt <- viewId
-  tag "option" @ att "value" (encodeArgument opt) @ selected (os.defaultOption == opt) $ text cnt
+  -- For "null" like arguments such as `Nothing` set `value=""` (but never `value="null"`, which breaks the round-trip)
+  let val = if toJSON opt == Null then "" else encodeArgument opt
+  tag "option" @ att "value" val @ selected (os.defaultOption == opt) $ text cnt
 
 
 -- | sets selected = true if the 'dropdown' predicate returns True


### PR DESCRIPTION
- [x] clear input on `ESC` 
- [x] add `back` button
- [x] ~~Selecting `Any` from "Language Family"  breaks round-trip.~~

   ~~Error: "Parse Input: parsing Example.Data.ProgrammingLanguage.LanguageFamily failed, expected String, but encountered Null".~~
   
   ~~Try it [here](https://hyperbole.live/data/filter).~~

   <img width="531" height="135" alt="hb-filter-any" src="https://github.com/user-attachments/assets/2ec705fc-036c-4bc0-85bc-fdc5786132df" />
   
   ~~**Fix:** Now [`<option>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/option) will be rendered to `<option value="">` in case it gets a `Nothing` or any other `Null` like value.~~
   

